### PR TITLE
refactor: Rename to rhproxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Insights-Proxy Container Images
+name: Build Insights Proxy (rhproxy-engine) Container Images
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
 
 env:
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
-  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'insights-proxy.source=github' || 'quay.expires-after=5d' }}
-  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'abellott/insights-proxy' }}
+  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'rhproxy-engine.source=github' || 'quay.expires-after=5d' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'abellott/rhproxy-engine' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: echo "RELEASE_TAG_AMD64=$([[ ${GITHUB_REF_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo ${GITHUB_REF_NAME%.[0-9]*}-amd64 || echo)" >> "$GITHUB_ENV"
 
-      - name: Build Amd64 Insights-Proxy image
+      - name: Build Amd64 rhproxy-engine image
         id: build-image-amd64
         uses: redhat-actions/buildah-build@v2
         with:
@@ -41,7 +41,7 @@ jobs:
             ./Containerfile
           labels: |
             ${{ env.EXPIRATION_LABEL }}
-            insights-proxy.backend.git_sha=${{ github.sha }}
+            rhproxy-engine.backend.git_sha=${{ github.sha }}
 
       - name: Push Amd64 To quay.io
         id: push-image-amd64
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: echo "RELEASE_TAG_ARM64=$([[ ${GITHUB_REF_NAME} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo ${GITHUB_REF_NAME%.[0-9]*}-arm64 || echo)" >> "$GITHUB_ENV"
 
-      - name: Build Arm64 Insights-Proxy image
+      - name: Build Arm64 rhproxy-engine image
         id: build-image-arm64
         uses: redhat-actions/buildah-build@v2
         with:
@@ -85,7 +85,7 @@ jobs:
             ./Containerfile
           labels: |
             ${{ env.EXPIRATION_LABEL }}
-            insights-proxy.backend.git_sha=${{ github.sha }}
+            rhproxy-engine.backend.git_sha=${{ github.sha }}
 
       - name: Push Arm64 To quay.io
         id: push-image-arm64

--- a/Containerfile
+++ b/Containerfile
@@ -19,16 +19,16 @@ ENV NGINX_CONF_PATH=${NGINX_BASE}/etc/nginx/nginx.conf
 ENV NGINX_CONFIGURATION_PATH=${NGINX_BASE}/etc/nginx.d
 ENV NGINX_LOG_PATH=/var/log/nginx
 
-# Let's declare the Insights-Proxy configurable parameters
-ENV INSIGHTS_PROXY_DISABLE="0"
-ENV INSIGHTS_PROXY_DEBUG_CONFIG="0"
-ENV INSIGHTS_PROXY_SERVICE_PORT=3128
-ENV INSIGHTS_PROXY_SERVER_NAMES="*.redhat.com"
-ENV INSIGHTS_PROXY_DNS_SERVER="1.1.1.1"
+# Let's declare the rhproxy configurable parameters
+ENV RHPROXY_DISABLE="0"
+ENV RHPROXY_DEBUG_CONFIG="0"
+ENV RHPROXY_SERVICE_PORT=3128
+ENV RHPROXY_SERVER_NAMES="*.redhat.com"
+ENV RHPROXY_DNS_SERVER="1.1.1.1"
 
-# Let's enable the Insights-Proxy web server parmaeters
-ENV INSIGHTS_WEB_SERVER_DISABLE="0"
-ENV INSIGHTS_WEB_SERVER_PORT=8443
+# Let's enable the rhproxy web server parameters
+ENV RHPROXY_WEB_SERVER_DISABLE="0"
+ENV RHPROXY_WEB_SERVER_PORT=8443
 
 WORKDIR ${APP_HOME}
 
@@ -145,11 +145,11 @@ RUN groupadd --gid ${NGINX_GID} ${NGINX_GROUP} \
 # Let's copy the built nginx
 COPY --from=build ${NGINX_BASE} ${NGINX_BASE}
 
-# Add Insights-Proxy sources:
+# Add rhproxy sources:
 ADD app/etc/nginx/nginx.conf.template ${NGINX_CONF_PATH}.template
 ADD app/etc/*.sh ${APP_ROOT}/etc/
 
-# Copy and set the Insights-Proxy entrypoint:
+# Copy and set the rhproxy entrypoint:
 COPY app/entrypoint.sh ${APP_ROOT}/.
 
 # Copy the web server content:
@@ -168,8 +168,8 @@ RUN chown ${NGINX_USER}:root /run /run/lock
 RUN chmod 775 /run /run/lock
 USER ${NGINX_UID}
 
-# Exposing the Insights Proxy and Web server ports
-EXPOSE ${INSIGHTS_PROXY_SERVICE_PORT}
-EXPOSE ${INSIGHTS_WEB_SERVER_PORT}
+# Exposing the rhproxy and Web server ports
+EXPOSE ${RHPROXY_SERVICE_PORT}
+EXPOSE ${RHPROXY_WEB_SERVER_PORT}
 
 CMD ["/bin/bash", "/opt/app-root/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 
-INSIGHTS_PROXY_CONTAINER_TAG ?= insights-proxy
+RHPROXY_CONTAINER_TAG ?= rhproxy-engine
 
 all:	help
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  help      show this help message"
-	@echo "  build     build the container image for the insights-proxy"
+	@echo "  build     build the container image for the rhproxy-engine"
 
 build:
 	podman build \
-		-t $(INSIGHTS_PROXY_CONTAINER_TAG) .
+		-t $(RHPROXY_CONTAINER_TAG) .
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# insights-proxy
-Insights Proxy to RedHat's Hybrid Cloud Console
+# rhproxy-engine
+Insights Proxy NGINX Engine to RedHat's Hybrid Cloud Console
 
 
 ## Architecture
@@ -16,7 +16,7 @@ Building the Insigihts Proxy container is provided via the Makefile. This can be
 $ make build
 ```
 
-This builds the `localhost/insights-proxy:latest` container image.
+This builds the `localhost/rhproxy-engine:latest` container image.
 
 ## Insights Proxy Documentation
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 #
-# Insights-Proxy Entrypoint
+# rhproxy-engine Entrypoint
 
 set -e
 
-export INSIGHTS_PROXY_NAME="Insights-Proxy"
+export RHPROXY_NAME="Insights Proxy"
 
 # Create the self-signed certificates if not provided.
-${APP_ROOT}/etc/insights_init_certs.sh
+${APP_ROOT}/etc/rhproxy_init_certs.sh
 
 # Let's make sure the download folder is created
 mkdir -p ${APP_DOWNLOAD}
 
 CONFIG_ENV_VARS="\
-\$INSIGHTS_PROXY_SERVICE_PORT,\
-\$INSIGHTS_PROXY_SERVER_NAMES,\
-\$INSIGHTS_PROXY_DNS_SERVER,\
-\$INSIGHTS_PROXY_DISABLE,\
-\$INSIGHTS_WEB_SERVER_PORT,\
-\$INSIGHTS_WEB_SERVER_DISABLE\
+\$RHPROXY_SERVICE_PORT,\
+\$RHPROXY_SERVER_NAMES,\
+\$RHPROXY_DNS_SERVER,\
+\$RHPROXY_DISABLE,\
+\$RHPROXY_WEB_SERVER_PORT,\
+\$RHPROXY_WEB_SERVER_DISABLE\
 "
 
 envsubst "${CONFIG_ENV_VARS}" < ${NGINX_CONF_PATH}.template > ${NGINX_CONF_PATH}
 
-if [ "${INSIGHTS_PROXY_DEBUG_CONFIG}" = "1" ]; then
+if [ "${RHPROXY_DEBUG_CONFIG}" = "1" ]; then
     echo
     echo "----------------------------------------------------------------------"
     echo "Environment Variables:"
@@ -37,5 +37,5 @@ if [ "${INSIGHTS_PROXY_DEBUG_CONFIG}" = "1" ]; then
     echo
 fi
 
-echo "Starting ${INSIGHTS_PROXY_NAME} ..."
+echo "Starting ${RHPROXY_NAME} ..."
 ${NGINX_BASE}/usr/sbin/nginx -g "daemon off;"

--- a/app/etc/nginx/nginx.conf.template
+++ b/app/etc/nginx/nginx.conf.template
@@ -15,12 +15,12 @@ http {
 
     # Let's tunnel only RedHat Insights upstream servers
     server {
-        listen        ${INSIGHTS_PROXY_SERVICE_PORT};
-        resolver      ${INSIGHTS_PROXY_DNS_SERVER} ipv6=off;
-        set $disabled ${INSIGHTS_PROXY_DISABLE};
+        listen        ${RHPROXY_SERVICE_PORT};
+        resolver      ${RHPROXY_DNS_SERVER} ipv6=off;
+        set $disabled ${RHPROXY_DISABLE};
 
         # Allowed Insights servers
-        server_name   ${INSIGHTS_PROXY_SERVER_NAMES};
+        server_name   ${RHPROXY_SERVER_NAMES};
 
         if ( $disabled = "1" ) {
             return  503;
@@ -43,9 +43,9 @@ http {
 
     # Let's deny all other requests
     server {
-        listen        ${INSIGHTS_PROXY_SERVICE_PORT};
-        resolver      ${INSIGHTS_PROXY_DNS_SERVER} ipv6=off;
-        set $disabled ${INSIGHTS_PROXY_DISABLE};
+        listen        ${RHPROXY_SERVICE_PORT};
+        resolver      ${RHPROXY_DNS_SERVER} ipv6=off;
+        set $disabled ${RHPROXY_DISABLE};
 
         server_name   ~.+;
 
@@ -76,9 +76,9 @@ http {
         include             /opt/app-root/nginx/etc/nginx/mime.types;
         default_type        application/octet-stream;
 
-        listen              ${INSIGHTS_WEB_SERVER_PORT} ssl http2;
-        listen              [::]:${INSIGHTS_WEB_SERVER_PORT} ssl http2;
-        set $disabled       ${INSIGHTS_WEB_SERVER_DISABLE};
+        listen              ${RHPROXY_WEB_SERVER_PORT} ssl http2;
+        listen              [::]:${RHPROXY_WEB_SERVER_PORT} ssl http2;
+        set $disabled       ${RHPROXY_WEB_SERVER_DISABLE};
 
         server_name         _;
         root                /opt/app-root/src;
@@ -87,8 +87,8 @@ http {
             return  503;
         }
 
-        ssl_certificate           "/opt/app-root/certs/insights-proxy.crt";
-        ssl_certificate_key       "/opt/app-root/certs/insights-proxy.key";
+        ssl_certificate           "/opt/app-root/certs/rhproxy.crt";
+        ssl_certificate_key       "/opt/app-root/certs/rhproxy.key";
         ssl_session_cache         shared:SSL:1m;
         ssl_session_timeout       10m;
         ssl_ciphers               PROFILE=SYSTEM;

--- a/app/etc/rhproxy_init_certs.sh
+++ b/app/etc/rhproxy_init_certs.sh
@@ -7,36 +7,36 @@ set -e
 # Let's make sure our certificates directory exists.
 mkdir -p "${APP_CERTS}"
 
-export CERT_PREFIX="insights-proxy"
+export CERT_PREFIX="rhproxy"
 export KEY_FILE="${APP_CERTS}/${CERT_PREFIX}.key"
 export CRT_FILE="${APP_CERTS}/${CERT_PREFIX}.crt"
 export PEM_FILE="${APP_CERTS}/${CERT_PREFIX}.pem"
 
 if [ -f "${KEY_FILE}" ] && [ -f "${CRT_FILE}" ]; then
-    echo "Using ${INSIGHTS_PROXY_NAME} certificates ..."
+    echo "Using ${RHPROXY_NAME} certificates ..."
     openssl rsa -in "${KEY_FILE}" -check
     openssl x509 -in "${CRT_FILE}" -text -noout
 elif [ ! -f "${KEY_FILE}" ] && [ ! -f "${CRT_FILE}" ]; then
-    echo "Creating ${INSIGHTS_PROXY_NAME} certificates ..."
+    echo "Creating ${RHPROXY_NAME} certificates ..."
     openssl req -x509 -nodes -days 365 -newkey rsa:4096 \
         -keyout "${KEY_FILE}" \
         -out "${CRT_FILE}" \
-        -subj "/C=US/ST=Raleigh/L=Raleigh/O=IT/OU=IT Department/CN=insights-proxy" \
+        -subj "/C=US/ST=Raleigh/L=Raleigh/O=IT/OU=IT Department/CN=rhproxy" \
         -addext "subjectAltName=DNS:localhost"
     chmod 600 "${KEY_FILE}"
 else
-    echo "Either the ${INSIGHTS_PROXY_NAME} ${CERT_PREFIX}.key or ${CERT_PREFIX}.crt certificate is missing in ${APP_CERTS}."
+    echo "Either the ${RHPROXY_NAME} ${CERT_PREFIX}.key or ${CERT_PREFIX}.crt certificate is missing in ${APP_CERTS}."
     exit 1
 fi
 
 if [ ! -f "${PEM_FILE}" ]; then
-    echo "Creating ${INSIGHTS_PROXY_NAME} PEM file ..."
+    echo "Creating ${RHPROXY_NAME} PEM file ..."
     cat "${KEY_FILE}" >  "${PEM_FILE}"
     cat "${CRT_FILE}" >> "${PEM_FILE}"
 fi
 
 
-if [ "${INSIGHTS_PROXY_DEBUG_CONFIG}" = "1" ]; then
+if [ "${RHPROXY_DEBUG_CONFIG}" = "1" ]; then
     echo
     echo "----------------------------------------------------------------------"
     echo "Available Certificates:"


### PR DESCRIPTION
Rename all INSIGHTS_PROXY things to rhproxy and rhproxy-engine

In RedHatInsights
- rhproxy is the quadlet service that gets installed (dnf install rhproxy)
- rhproxy-engine is the NGINX container for rhproxy