### PR TITLE
fix: Select to pull latest 9.4 tag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal as base
+FROM registry.access.redhat.com/ubi9-minimal:9.4 as base
 
 # Let's declare where we're installing nginx
 ENV APP_ROOT=/opt/app-root


### PR DESCRIPTION
- this build gives as a 9.4 consistent build, plus the 9.4 is tagged to the latest on that release, which also gives us the latest CVE fixes for 9.4.