### PR TITLE
feat: include server names config files instead of a single environment variable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,7 @@ ENV APP_ROOT=/opt/app-root
 ENV APP_HOME=${APP_ROOT}/src
 ENV APP_DOWNLOAD=${APP_ROOT}/download
 ENV APP_CERTS=${APP_ROOT}/certs
+ENV APP_RHPROXY_ENV=${APP_ROOT}/rhproxy-env
 
 # Let's define the nginx defaults
 ENV NGINX_VERSION="1.24.0"
@@ -15,16 +16,20 @@ ENV NGINX_GID="1001"
 ENV NGINX_BASE=${APP_ROOT}/nginx
 ENV NGINX_DEFAULT_CONF_PATH=${NGINX_BASE}/etc/nginx.default.d
 ENV NGINX_PERL_MODULE_PATH=${NGINX_BASE}/etc/perl
-ENV NGINX_CONF_PATH=${NGINX_BASE}/etc/nginx/nginx.conf
+ENV NGINX_CONF_DIR=${NGINX_BASE}/etc/nginx
+ENV NGINX_CONF_PATH=${NGINX_CONF_DIR}/nginx.conf
 ENV NGINX_CONFIGURATION_PATH=${NGINX_BASE}/etc/nginx.d
 ENV NGINX_LOG_PATH=/var/log/nginx
+
+# Let's define the rhproxy defaults
+ENV RHPROXY_CONF_DIR=${NGINX_CONF_DIR}/rhproxy
 
 # Let's declare the rhproxy configurable parameters
 ENV RHPROXY_DISABLE="0"
 ENV RHPROXY_DEBUG_CONFIG="0"
 ENV RHPROXY_SERVICE_PORT=3128
-ENV RHPROXY_SERVER_NAMES="*.redhat.com"
 ENV RHPROXY_DNS_SERVER="1.1.1.1"
+
 
 # Let's enable the rhproxy web server parameters
 ENV RHPROXY_WEB_SERVER_DISABLE="0"
@@ -146,7 +151,9 @@ RUN groupadd --gid ${NGINX_GID} ${NGINX_GROUP} \
 COPY --from=build ${NGINX_BASE} ${NGINX_BASE}
 
 # Add rhproxy sources:
+RUN mkdir -p ${RHPROXY_CONF_DIR}
 ADD app/etc/nginx/nginx.conf.template ${NGINX_CONF_PATH}.template
+ADD app/etc/nginx/*.server_names ${RHPROXY_CONF_DIR}
 ADD app/etc/*.sh ${APP_ROOT}/etc/
 
 # Copy and set the rhproxy entrypoint:
@@ -156,9 +163,10 @@ COPY app/entrypoint.sh ${APP_ROOT}/.
 RUN mkdir -p ${APP_HOME}/img/
 COPY app/src/*.html ${APP_HOME}/.
 
-# Let's make sure we have our certs and downloads directories created:
+# Let's make sure we have our certs, downloads and rhproxy-env directories are created:
 RUN mkdir -p ${APP_CERTS}
 RUN mkdir -p ${APP_DOWNLOAD}
+RUN mkdir -p ${APP_RHPROXY_ENV}
 
 # Let's have nginx own the app
 USER 0

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -7,21 +7,39 @@ set -e
 export RHPROXY_NAME="Insights Proxy"
 
 # Create the self-signed certificates if not provided.
-${APP_ROOT}/etc/rhproxy_init_certs.sh
+"${APP_ROOT}/etc/rhproxy_init_certs.sh"
 
 # Let's make sure the download folder is created
-mkdir -p ${APP_DOWNLOAD}
+mkdir -p "${APP_DOWNLOAD}"
 
 CONFIG_ENV_VARS="\
 \$RHPROXY_SERVICE_PORT,\
-\$RHPROXY_SERVER_NAMES,\
 \$RHPROXY_DNS_SERVER,\
 \$RHPROXY_DISABLE,\
 \$RHPROXY_WEB_SERVER_PORT,\
 \$RHPROXY_WEB_SERVER_DISABLE\
 "
 
-envsubst "${CONFIG_ENV_VARS}" < ${NGINX_CONF_PATH}.template > ${NGINX_CONF_PATH}
+# If the rhproxy services provides us with servers configuration files, let's
+# import those and create the server_names config files needed by NGINX.
+function server_to_server_names() {
+  if [ -s "${1}" ]; then
+    cat "${1}" \
+    | egrep -v "^#|^$|^[ \t]*$" \
+    | sort -u \
+    | sed -e 's/^/server_name /g' -e 's/$/;/g'
+  fi
+}
+
+if [ -s "${APP_RHPROXY_ENV}/redhat.servers" ]; then
+  server_to_server_names "${APP_RHPROXY_ENV}/redhat.servers" > "${RHPROXY_CONF_DIR}/redhat.server_names"
+fi
+
+if [ -s "${APP_RHPROXY_ENV}/mirror.servers" ]; then
+  server_to_server_names "${APP_RHPROXY_ENV}/mirror.servers" > "${RHPROXY_CONF_DIR}/mirror.server_names"
+fi
+
+envsubst "${CONFIG_ENV_VARS}" < "${NGINX_CONF_PATH}.template" > "${NGINX_CONF_PATH}"
 
 if [ "${RHPROXY_DEBUG_CONFIG}" = "1" ]; then
     echo
@@ -33,9 +51,19 @@ if [ "${RHPROXY_DEBUG_CONFIG}" = "1" ]; then
     echo "----------------------------------------------------------------------"
     echo "Nginx configuation file: ${NGINX_CONF_PATH}"
     echo
-    cat ${NGINX_CONF_PATH}
+    cat "${NGINX_CONF_PATH}"
+    echo
+    echo "----------------------------------------------------------------------"
+    echo "RedHat server names: ${RHPROXY_CONF_DIR}/redhat.server_names"
+    echo
+    cat "${RHPROXY_CONF_DIR}/redhat.server_names"
+    echo
+    echo "----------------------------------------------------------------------"
+    echo "DNF mirror server names: ${RHPROXY_CONF_DIR}/mirror.server_names"
+    echo
+    cat "${RHPROXY_CONF_DIR}/mirror.server_names"
     echo
 fi
 
 echo "Starting ${RHPROXY_NAME} ..."
-${NGINX_BASE}/usr/sbin/nginx -g "daemon off;"
+"${NGINX_BASE}/usr/sbin/nginx" -g "daemon off;"

--- a/app/etc/nginx/mirror.server_names
+++ b/app/etc/nginx/mirror.server_names
@@ -1,0 +1,1 @@
+# DNF mirror server names

--- a/app/etc/nginx/nginx.conf.template
+++ b/app/etc/nginx/nginx.conf.template
@@ -19,8 +19,11 @@ http {
         resolver      ${RHPROXY_DNS_SERVER} ipv6=off;
         set $disabled ${RHPROXY_DISABLE};
 
-        # Allowed Insights servers
-        server_name   ${RHPROXY_SERVER_NAMES};
+        # Supported RedHat Insights server names
+        include       rhproxy/redhat.server_names;
+
+        # Supported DNF mirror server names
+        include       rhproxy/mirror.server_names;
 
         if ( $disabled = "1" ) {
             return  503;

--- a/app/etc/nginx/redhat.server_names
+++ b/app/etc/nginx/redhat.server_names
@@ -1,0 +1,3 @@
+# RedHat server names
+server_name *.redhat.com;
+server_name *.fedoraproject.org;


### PR DESCRIPTION

- support redhat.server_names and mirror.server_names as included by the nginx.conf
- include default for these files
- support for redhat.servers and mirror.servers files to be mounted and provided by the rhproxy system service.
- concert the server names from the redhat.servers and mirror.servers to the NGINX support server_name declaration for inclusion by the config file.
- Log the content of the server_names files upon container startup in addition to the environment variables.