### PR TITLE
Create x.y.z versioned multi-platform manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,3 +123,13 @@ jobs:
           template: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-ARCH
           target: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
+      - name: Push Versioned Manifest
+        id: push-versioned-manifest
+        if: contains( env.RELEASE_TAG, '.' )
+        uses: pixelfederation/gh-action-manifest-tool@v0.1.7
+        with:
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_PASSWORD }}
+          platforms: linux/amd64,linux/arm64
+          template: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF_NAME}-ARCH
+          target: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF_NAME}


### PR DESCRIPTION
- If building a release container manifest (ie. x.y), let's make sure we also create the full versioned manifest (ie. x.y.z) as the latest rhproxy will require the x.y.z multi-platform manifests.