### PR TITLE
Adding image tags for Konflux builds of the container

### DIFF
--- a/.tekton/rhproxy-engine-container-pull-request.yaml
+++ b/.tekton/rhproxy-engine-container-pull-request.yaml
@@ -419,6 +419,8 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value: ["pr-{{pull_request_number}}"]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
For konflux image tags:

- Adding the "pr-#" image tag for PR builds