### PR TITLE
Preferred to use an RE2 CEL match for the exact refs/tags/#.#.#

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/")
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.matches("^refs\/tags\/[0-9]+\.[0-9]+\.[0-9]+$")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-proxy-container


### PR DESCRIPTION
github tag so we don't create non release builds.