### PR TITLE
with correct tag builds for x.y.z and x.y, removing the 5 day expiration

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -22,8 +22,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/insights-proxy-ipp-tenant/rhproxy-engine-container:{{revision}}
-  - name: image-expires-after
-    value: 5d
   - name: dockerfile
     value: /Containerfile
   pipelineSpec:


### PR DESCRIPTION
- with correct tag builds for x.y.z and x.y, removing the 5 day image expiration life limit.