### PR TITLE
Added the push-images-to-public-repo task to the release pipeline

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -514,6 +514,50 @@ spec:
         operator: in
         values:
         - "false"
+    - name: push-images-to-public-repo
+      image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
+      params:
+      - name: destination_quay_secret
+        value: insights-proxy-rhproxy-engine-bot-token
+      env:
+        - name: DEST_QUAY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.destination_quay_secret)
+              key: username
+        - name: DEST_QUAY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.destination_quay_secret)
+              key: password
+      script: |
+        #!/usr/bin/env bash
+        #
+        # Script to push the released x.y.z and x.y tagged images to the public repo
+        SOURCE_REPO="$(tasks.build-image-index.results.IMAGE_URL)"
+        TARGET_REPO="quay.io/insights_proxy/rhproxy-engine"
+
+        TARGET_RELEASE="$(tasks.init-env.results.target_release)"
+        MINOR_RELEASE="$(tasks.init-env.results.minor_release)"
+
+        echo "Pushing images to the public facing repository ..."
+        echo "Source Repo:   ${SOURCE_REPO}"
+        echo "Target Repo:   ${TARGET_REPO}"
+
+        # Copy the Target x.y.z release
+        skopeo copy --dest-username "${DEST_QUAY_USERNAME}" --dest-password "${DEST_QUAY_PASSWORD}" \
+          "${SOURCE_REPO}:${TARGET_RELEASE}" \
+          "${TARGET_REPO}:${TARGET_RELEASE}"
+        echo "Pushed Image:  ${TARGET_REPO}:${TARGET_RELEASE}"
+
+        # Copy the Minor x.y release
+        skopeo copy --dest-username "${DEST_QUAY_USERNAME}" --dest-password "${DEST_QUAY_PASSWORD}" \
+          "${SOURCE_REPO}:${MINOR_RELEASE}" \
+          "${TARGET_REPO}:${MINOR_RELEASE}"
+        echo "Pushed Image:  ${TARGET_REPO}:${MINOR_RELEASE}"
+      runAfter:
+      - push-dockerfile
+      - apply-tags
     workspaces:
     - name: git-auth
       optional: true


### PR DESCRIPTION
- Added the push-images-to-public-repo to the release pipeline we push the released patch targets (x.y.z) and
minor release (x.y) to the public facing quay.io repo.