### PR TITLE
Missing the repository transport specification for skopeo 

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -546,14 +546,14 @@ spec:
 
             # Copy the Target x.y.z release
             skopeo copy --dest-username "${DEST_QUAY_USERNAME}" --dest-password "${DEST_QUAY_PASSWORD}" \
-              "${SOURCE_IMAGE}" \
-              "${TARGET_REPO}:${TARGET_RELEASE}"
+              "docker://${SOURCE_IMAGE}" \
+              "docker://${TARGET_REPO}:${TARGET_RELEASE}"
             echo "Pushed Image:  ${TARGET_REPO}:${TARGET_RELEASE}"
 
             # Copy the Minor x.y release
             skopeo copy --dest-username "${DEST_QUAY_USERNAME}" --dest-password "${DEST_QUAY_PASSWORD}" \
-              "${SOURCE_IMAGE}" \
-              "${TARGET_REPO}:${MINOR_RELEASE}"
+              "docker://${SOURCE_IMAGE}" \
+              "docker://${TARGET_REPO}:${MINOR_RELEASE}"
             echo "Pushed Image:  ${TARGET_REPO}:${MINOR_RELEASE}"
       runAfter:
       - apply-tags


### PR DESCRIPTION
- Missing the source and destination repository transport (docker://) for the skopeo image copy tool.