### PR TITLE
preferring service utils from kunflux-ci image than ubuntu

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -150,7 +150,7 @@ spec:
           description: Minor Release Tag build (x.y)
         steps:
         - name: init-env
-          image: ubuntu
+          image: quay.io/konflux-ci/release-service-utils:e633d51cd41d73e4b3310face21bb980af7a662f
           script: |
             #!/usr/bin/env bash
             #


### PR DESCRIPTION
- preferring service utils from kunflux-ci image than ubuntu which sometimes fails to be pulled.