### PR TITLE
Push release builds to public repo after malware detection

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -567,6 +567,7 @@ spec:
       runAfter:
       - apply-tags
       - clair-scan
+      - clamav-scan
       - sast-snyk-check
       - rpms-signature-scan
     workspaces:


### PR DESCRIPTION
- Push release builds to the public repo after the clamav-scan malware detection.