### PR TITLE
Update to use Konflux supported RPM repos identifiers

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,2730 +5,2730 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/a/annobin-12.65-1.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1090013
     checksum: sha256:4b30b05d23de42dc5af50578b46d9f0ff0e12c3fa429d59940949b577a1bcd9e
     name: annobin
     evr: 12.65-1.el9
     sourcerpm: annobin-12.65-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/b/brotli-1.0.9-7.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 318978
     checksum: sha256:6c6890d7a0bcacbf89f2ac39dadd42d505b375130a56cae6401a31e4b33b23e3
     name: brotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/b/brotli-devel-1.0.9-7.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 35163
     checksum: sha256:4fa52d3d27404f7c08c9ad1d8b3cf7e758888f28ebae2a06634b859be486d229
     name: brotli-devel
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/b/bzip2-devel-1.0.8-10.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 220464
     checksum: sha256:6c1bdc97e783fee61bade254ebbca48417e813d3f6e42b18e4657f45d3122a85
     name: bzip2-devel
     evr: 1.0.8-10.el9_5
     sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cairo-1.17.4-7.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 664919
     checksum: sha256:61fd5cb8506a27090331ef33fd2d14cdbbe530f42ab9179e4288d9797c09e398
     name: cairo
     evr: 1.17.4-7.el9
     sourcerpm: cairo-1.17.4-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cmake-filesystem-3.26.5-2.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 23401
     checksum: sha256:c76e4d4a355a4f6599bee009c9b4408e6b82c31265f2db824efdeb278d596024
     name: cmake-filesystem
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10795955
     checksum: sha256:fd6561d7ca6a5ec7a9d9c17c623d97c24eec8f6c8de91081ba95343ebd0de7c2
     name: cpp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/d/dwz-0.14-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 131062
     checksum: sha256:adbbefef8e5ee6d5fe48d51555fa41a1d31770fd1bb8f5fac11da777a36c2a63
     name: dwz
     evr: 0.14-3.el9
     sourcerpm: dwz-0.14-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/e/efi-srpm-macros-6-2.el9_0.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24452
     checksum: sha256:1a1fa7561f5cef960b36c6a796d8a6fb4af70511118dacbfd5f707181a6c02fe
     name: efi-srpm-macros
     evr: 6-2.el9_0
     sourcerpm: efi-rpm-macros-6-2.el9_0.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fontconfig-2.14.0-2.el9_1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 310419
     checksum: sha256:b80def85208fe166b46b74a89c10892190d6b9b1cb33e1d794249909aa76c353
     name: fontconfig
     evr: 2.14.0-2.el9_1
     sourcerpm: fontconfig-2.14.0-2.el9_1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fontconfig-devel-2.14.0-2.el9_1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 182284
     checksum: sha256:ba52e4e49526430af31af31effdd47000d1c7babc267cb279015f7f2acfcf5a6
     name: fontconfig-devel
     evr: 2.14.0-2.el9_1
     sourcerpm: fontconfig-2.14.0-2.el9_1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 30140
     checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
     name: fonts-srpm-macros
     evr: 1:2.0.5-7.el9.1
     sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/f/freetype-devel-2.10.4-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1161603
     checksum: sha256:bd677d3fa70f73fe5b609ab78e44d3b28c852e563787a00ffd6899458723b42f
     name: freetype-devel
     evr: 2.10.4-9.el9
     sourcerpm: freetype-2.10.4-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 31300907
     checksum: sha256:0adab9938458e552e3d5433c668d7abb946be0a81b2b510a201136efbca51601
     name: gcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-c++-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12999288
     checksum: sha256:a9ff0bd2a2b3483e07dcf87f8137a6358f36f5300c934b90500f119f884e3463
     name: gcc-c++
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 42047
     checksum: sha256:a0bf9c6f269440a530dbd57274fd79f0c5e9b463d907c4810affd33ee59a28d6
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gd-2.3.2-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 133375
     checksum: sha256:912ee14e56c7c01f456c00aa69a15c57e0ddac5386a9c05e52832d7aea0f306f
     name: gd
     evr: 2.3.2-3.el9
     sourcerpm: gd-2.3.2-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gd-devel-2.3.2-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 42334
     checksum: sha256:a4e41c3f8276711d0c2c683b733e22acdbebdf343b462890b738f3aec1395f3d
     name: gd-devel
     evr: 2.3.2-3.el9
     sourcerpm: gd-2.3.2-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9252
     checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
     name: ghc-srpm-macros
     evr: 1.5.0-6.el9
     sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glib2-devel-2.68.4-14.el9_4.1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 569012
     checksum: sha256:bf8e21456b7f9d55e4ccc50668a3db4ff0fee311b5339796a9419e324f61f9a1
     name: glib2-devel
     evr: 2.68.4-14.el9_4.1
     sourcerpm: glib2-2.68.4-14.el9_4.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 564979
     checksum: sha256:ad0568d684a6122506f72ba83b5868930810520dabb229c37148d489c65becc9
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/go-srpm-macros-3.6.0-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29052
     checksum: sha256:831fb63c546286b319f9b2a9284ff8c1e34668172ac2d37dc722e7e8dca07120
     name: go-srpm-macros
     evr: 3.6.0-3.el9
     sourcerpm: go-rpm-macros-3.6.0-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/gpm-libs-1.20.7-29.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 23277
     checksum: sha256:6a509fe06b994fcb3fd39bef1aca32381302473bf8b919e3992ec0ec543bafb0
     name: gpm-libs
     evr: 1.20.7-29.el9
     sourcerpm: gpm-1.20.7-29.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/g/graphite2-devel-1.3.14-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24602
     checksum: sha256:7c1eee902960bf27a492a7eaa2ecd324830b7ecfedb80de3bff606f3476468da
     name: graphite2-devel
     evr: 1.3.14-9.el9
     sourcerpm: graphite2-1.3.14-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/h/harfbuzz-devel-2.7.4-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 358742
     checksum: sha256:7e8f25f2425f4e1797714f4a923324f7024ea34c9bbe37039b1b5a42f5440436
     name: harfbuzz-devel
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/h/harfbuzz-icu-2.7.4-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15271
     checksum: sha256:3a1b0ed8e1fbc7858f6810e72ad39448994ff1af26a6537d1d7554a5ac8e0a36
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 57006
     checksum: sha256:f9fd62dfb74900a238cba5346d3932f32a802b6d6a161c47935938f392a7adf2
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-503.26.1.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
-    size: 3890829
-    checksum: sha256:16663c5a90ef1be3bf9348dc14bc78aa6eca55f7daf8bbdae078fa513784dcb9
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-503.29.1.el9_5.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 3896005
+    checksum: sha256:12f60a30fc3c080b2a4b818b56ccde4ec8e0cf396fa92c05b5fd0b951383cfac
     name: kernel-headers
-    evr: 5.14.0-503.26.1.el9_5
-    sourcerpm: kernel-5.14.0-503.26.1.el9_5.src.rpm
+    evr: 5.14.0-503.29.1.el9_5
+    sourcerpm: kernel-5.14.0-503.29.1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17792
     checksum: sha256:7e891fa264fb538bf4a26aa94e91ff0c3084bf2613e2061dbb6f4f0c26856777
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libICE-1.0.10-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 73688
     checksum: sha256:936ea88bf523268d8400fed78c3198b6037aea159a82bc84e5c8e8989993c76b
     name: libICE
     evr: 1.0.10-8.el9
     sourcerpm: libICE-1.0.10-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libSM-1.2.3-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 44464
     checksum: sha256:0c76c6d8ba303be7f63887d960bc05c1d5fc87cf6305a9cd2d587df28dfcf28a
     name: libSM
     evr: 1.2.3-10.el9
     sourcerpm: libSM-1.2.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libX11-1.7.0-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 651969
     checksum: sha256:24b9b137c48d19673c8d853404b978304bdc2ace3a2270e55baf5e483da67454
     name: libX11
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libX11-common-1.7.0-9.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 214154
     checksum: sha256:cf55b0765528c4bf0176549f5835558c5883f3a918a71ca0d56a51e263f93d39
     name: libX11-common
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libX11-devel-1.7.0-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1151140
     checksum: sha256:48163aedb618f5c55daa0c6c3d1e840c32f0fe8d854b51519b0e58c21cf94668
     name: libX11-devel
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libX11-xcb-1.7.0-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12439
     checksum: sha256:647ab744a9bc83e65cd5d70cb861af9315dd2fa34fa82c92824e2bb7f0937c8e
     name: libX11-xcb
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXau-1.0.9-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 34407
     checksum: sha256:e9e34ac759a87357a5fa3d4155985a17b56967b3e036c7a438cc4314c0c23456
     name: libXau
     evr: 1.0.9-8.el9
     sourcerpm: libXau-1.0.9-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXau-devel-1.0.9-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17448
     checksum: sha256:4e762806f3cafa46aa8560058befd4a5d328b21a4df948b650b7655522d1ad3d
     name: libXau-devel
     evr: 1.0.9-8.el9
     sourcerpm: libXau-1.0.9-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXext-1.3.4-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 41839
     checksum: sha256:f72c5e42c9fac94f410cb0f58fcf6ce718575b6703e4f8adf83b2a4860a706dc
     name: libXext
     evr: 1.3.4-8.el9
     sourcerpm: libXext-1.3.4-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXpm-3.5.13-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 60821
     checksum: sha256:81ccc3b7c8275e95cbad1d25df6de9343fb4a445002d65bda7d15df11e668965
     name: libXpm
     evr: 3.5.13-10.el9
     sourcerpm: libXpm-3.5.13-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXpm-devel-3.5.13-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 38400
     checksum: sha256:3b7676f1143d9cf95e6da641df3704ac75462c367f69e2353ee7e0a8d35f0b99
     name: libXpm-devel
     evr: 3.5.13-10.el9
     sourcerpm: libXpm-3.5.13-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXrender-0.9.10-16.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29483
     checksum: sha256:06920454ec27e62fd482834d72ef6a6d3b3454ef111e5e7843355ed3d0ae20b5
     name: libXrender
     evr: 0.9.10-16.el9
     sourcerpm: libXrender-0.9.10-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libXt-1.2.0-6.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 179996
     checksum: sha256:d6f1063a50c4d41b9e660f3988faf4fcebeb69b0e8e6b6602cc16a47e7f37780
     name: libXt
     evr: 1.2.0-6.el9
     sourcerpm: libXt-1.2.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 413819
     checksum: sha256:3febfe157847f68e8c94796eb4a0e2d4c3c660b33c91ad068dd75f785ae76fa0
     name: libasan
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libblkid-devel-2.37.4-20.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18757
     checksum: sha256:d9fbb3b593b1e2089420c639def1d425b0d15b54017edfc875a8ac5902a12f61
     name: libblkid-devel
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libdatrie-0.2.13-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 34835
     checksum: sha256:f804d5f2fd27858d39f1a1c4e76864702b1d24e8d49df77737a547d80d1ee61f
     name: libdatrie
     evr: 0.2.13-4.el9
     sourcerpm: libdatrie-0.2.13-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libffi-devel-3.4.2-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 31109
     checksum: sha256:5cbe643ebd6c7608b127ccb0eaff9320db2e77b60dd79a3bfbf1b49cd1877bd6
     name: libffi-devel
     evr: 3.4.2-8.el9
     sourcerpm: libffi-3.4.2-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libgpg-error-devel-1.42-5.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 70304
     checksum: sha256:0d815a4a6adc7b4a5bf19770ae55308c997af8e50274fe3f2b8fc4aeaccc086c
     name: libgpg-error-devel
     evr: 1.42-5.el9
     sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libicu-devel-67.1-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 964907
     checksum: sha256:f4e34da81a26d20a4434dd35f0445044cf3b1b4a5ee6030aebca9e10d9eb35ae
     name: libicu-devel
     evr: 67.1-9.el9
     sourcerpm: icu-67.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libjpeg-turbo-2.0.90-7.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 175739
     checksum: sha256:b549971d7418fffff89092888c8d213dd63401f4b9cd2ecd1a9892c7cee9ab24
     name: libjpeg-turbo
     evr: 2.0.90-7.el9
     sourcerpm: libjpeg-turbo-2.0.90-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libjpeg-turbo-devel-2.0.90-7.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 104818
     checksum: sha256:d455116c42fe8411808dd1be01ef488b33744a8bd1c372882b2fa41c9b7507b3
     name: libjpeg-turbo-devel
     evr: 2.0.90-7.el9
     sourcerpm: libjpeg-turbo-2.0.90-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmount-devel-2.37.4-20.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 19447
     checksum: sha256:e5c3882177255a6f7fa93e947038c3c3b4d71581c2f18ebe9742ee52aa5173c9
     name: libmount-devel
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 67120
     checksum: sha256:3763354a5f45d886f9976eec20eb34f8afc2144c69ffba07de546f2820893c70
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libpng-devel-1.6.37-12.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 304418
     checksum: sha256:c55ad4e0fa23fbed2dc2004e0c36f90505112c829c1c7d411492e4075220568e
     name: libpng-devel
     evr: 2:1.6.37-12.el9
     sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libselinux-devel-3.6-1.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 167216
     checksum: sha256:580e3f74b6dc54b8569a670e51c935f868caf0704781771ec2009a75df6137c6
     name: libselinux-devel
     evr: 3.6-1.el9
     sourcerpm: libselinux-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libsepol-devel-3.6-1.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 52595
     checksum: sha256:8a40b91a8aae661cc408dbdc86fde7bce01051eb74d5d76c1ea0226ab63eeebc
     name: libsepol-devel
     evr: 3.6-1.el9
     sourcerpm: libsepol-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 2526795
     checksum: sha256:83a2006137335a9b17a05a02a54481abcdfd295b280b924c51caaacd7bf07ad6
     name: libstdc++-devel
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libthai-0.1.28-8.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 215793
     checksum: sha256:211edfbccb7c4cf828a1e078a9b4802f60b783f8e881696efb6cbf018b81cf30
     name: libthai
     evr: 0.1.28-8.el9
     sourcerpm: libthai-0.1.28-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtiff-4.4.0-13.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 200745
     checksum: sha256:b53246df9781875e230a01a03e338ceee5c5805b64c39120cbe752f50aa1253a
     name: libtiff
     evr: 4.4.0-13.el9
     sourcerpm: libtiff-4.4.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libtiff-devel-4.4.0-13.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 572657
     checksum: sha256:5de4855d43499cbc0fdcb67ae9f8119364b444787a00797c0c477695751140b6
     name: libtiff-devel
     evr: 4.4.0-13.el9
     sourcerpm: libtiff-4.4.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libubsan-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 183667
     checksum: sha256:0751fe4ed4571b48dbca8664a16b410030ec76e2f5d71234807751458d717f31
     name: libubsan
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libwebp-1.2.0-8.el9_3.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 272276
     checksum: sha256:5692fd846f9b41b3b6d6194f80dc52248c2ae1e7b0560b29bd0ed2f5bcb4506a
     name: libwebp
     evr: 1.2.0-8.el9_3
     sourcerpm: libwebp-1.2.0-8.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libwebp-devel-1.2.0-8.el9_3.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 36884
     checksum: sha256:6ad97214b40f00013141412500deca57573c493b8325e437e2c65e88053a7552
     name: libwebp-devel
     evr: 1.2.0-8.el9_3
     sourcerpm: libwebp-1.2.0-8.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcb-1.13.1-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 252623
     checksum: sha256:d98d6099494f737daa25cea2987a784f1bd2ba54293c5259dbcb326f64e7bbce
     name: libxcb
     evr: 1.13.1-9.el9
     sourcerpm: libxcb-1.13.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcb-devel-1.13.1-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1617304
     checksum: sha256:c43767ba7a125dc4613665fce1dbd719d97267b366ad06de8e85871fa36d394f
     name: libxcb-devel
     evr: 1.13.1-9.el9
     sourcerpm: libxcb-1.13.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 33051
     checksum: sha256:9d621f33df35b9c274b8d65457d6c67fc1522b6c62cf7b2341a4a99f39a93507
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxml2-devel-2.9.13-6.el9_5.1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 923566
     checksum: sha256:186738c4354169e5b704b536e842db74c8042f85402acdd724bd5518772561b4
     name: libxml2-devel
     evr: 2.9.13-6.el9_5.1
     sourcerpm: libxml2-2.9.13-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxslt-1.1.34-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 249008
     checksum: sha256:bd15d510eda3fdf9440b68a3fa85b95cbab060b3e194e8669193c7dc268892f3
     name: libxslt
     evr: 1.1.34-9.el9
     sourcerpm: libxslt-1.1.34-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/libxslt-devel-1.1.34-9.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 331576
     checksum: sha256:b4f3248ab49cec2e4d9def411404101d0cbe7acd4462160caf0e57f2f3d38130
     name: libxslt-devel
     evr: 1.1.34-9.el9
     sourcerpm: libxslt-1.1.34-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/llvm-libs-18.1.8-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25443053
     checksum: sha256:bc24a58435245a983081aa0df5793d04bcebed94caf2e19c949cd4bd44cd7e33
     name: llvm-libs
     evr: 18.1.8-3.el9
     sourcerpm: llvm-18.1.8-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10476
     checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
     name: lua-srpm-macros
     evr: 1-6.el9
     sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9270
     checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
     name: ocaml-srpm-macros
     evr: 6-6.el9
     sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 8807
     checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
     name: openblas-srpm-macros
     evr: 2-11.el9
     sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 4649968
     checksum: sha256:ef8529d34eaadf43c95be9afda9e3d98a48d66fa184b246fe549b2dfd8d80483
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre-cpp-8.44-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26773
     checksum: sha256:c2fe0ce9b973902ef670187fbc8a6ab061f77a371dcd26afdb8b08b2a7f8527a
     name: pcre-cpp
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre-devel-8.44-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 522441
     checksum: sha256:3b4d4cf28fa8a4970fa0d20c0c34056aa8b04516764f1fe99ef7a7be3dcec438
     name: pcre-devel
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre-utf16-8.44-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 172108
     checksum: sha256:46d829467bc41118a15fcef940dd18a247b6610d61af26e9074acbc6c761f5d9
     name: pcre-utf16
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre-utf32-8.44-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 164050
     checksum: sha256:c56242c8c7f82bd797e8370679fcf692f52c60d138c9850dd0f3b3a50cf3a0ae
     name: pcre-utf32
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre2-devel-10.40-6.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 528574
     checksum: sha256:58600c82959cc9ed11bf8e353a1744faf1bad7629dde5efcccc2e620fbc601ea
     name: pcre2-devel
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre2-utf16-10.40-6.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 202210
     checksum: sha256:10fa13474654d43c785714d2250aa5db45a52b672d6ef2ba35d168e86522d5d4
     name: pcre2-utf16
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pcre2-utf32-10.40-6.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 192622
     checksum: sha256:7a953c81ff18f05fba47b636e813b410e938db1f934c63b207b14bf0b52c4ad3
     name: pcre2-utf32
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-5.32.1-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12521
     checksum: sha256:e137b89a16ef2e1cc87686607823d0d87b9b284302504665fbfc63d07dc4629d
     name: perl
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 52041
     checksum: sha256:3d252e247a41978a10faef66931ac5fb2525c7fa708d8caa537d368ef5ba62ce
     name: perl-Algorithm-Diff
     evr: 1.2010-4.el9
     sourcerpm: perl-Algorithm-Diff-1.2010-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Archive-Tar-2.38-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 77744
     checksum: sha256:5cf97230d350543cdf34f379dc04e1383f89591ad76768b5a2738b474cdec404
     name: perl-Archive-Tar
     evr: 2.38-6.el9
     sourcerpm: perl-Archive-Tar-2.38-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Archive-Zip-1.68-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 118766
     checksum: sha256:2237a7cdfa30cda2ad475cb6ee5796f1e4cafa07e8760e08bca8d252cd6eb51d
     name: perl-Archive-Zip
     evr: 1.68-6.el9
     sourcerpm: perl-Archive-Zip-1.68-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Attribute-Handlers-1.01-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 28435
     checksum: sha256:03d4f6339d78bf32658aa68b713e15a01ff544e88a7565e8ee595e053b6ec8ea
     name: perl-Attribute-Handlers
     evr: 1.01-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-AutoSplit-5.74-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22186
     checksum: sha256:d962ffc07516d9f0ed0d9a5c21e16677598afa8f10a40c6555ae9a35e6a2d43b
     name: perl-AutoSplit
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-B-1.80-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 188904
     checksum: sha256:78fa2f2d5ac4356a7f46d888aebd31e52da12553f8fd6a6636c24b5eaa670feb
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Benchmark-1.23-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 27531
     checksum: sha256:b19c10012210bfdd3566986e4222cd94183e56e496d3e2ddf03743c45689818b
     name: perl-Benchmark
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-2.29-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 588870
     checksum: sha256:b38e3427041166797b36980580c2144835342cefeacd6effca184ac3e526bc84
     name: perl-CPAN
     evr: 2.29-3.el9
     sourcerpm: perl-CPAN-2.29-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17060
     checksum: sha256:35687783ded44b01c37af59f66499b42e10df074c36608fc3f84bd4ae082c852
     name: perl-CPAN-DistnameInfo
     evr: 0.12-23.el9
     sourcerpm: perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-2.150010-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 210745
     checksum: sha256:ec35026baabe720d7c880f896f84271f0c408c56d3fea6d7c5d22580ac175690
     name: perl-CPAN-Meta
     evr: 2.150010-460.el9
     sourcerpm: perl-CPAN-Meta-2.150010-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 35205
     checksum: sha256:eca17976f76fd8d31eda995a9ced2d813c1c94b9efafa1a83454fb120be62784
     name: perl-CPAN-Meta-Requirements
     evr: 2.140-461.el9
     sourcerpm: perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29542
     checksum: sha256:b21eb298e56bc6623257cae1434198789e80ab92b818af4e29514a7bbc6f5910
     name: perl-CPAN-Meta-YAML
     evr: 0.018-461.el9
     sourcerpm: perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Bzip2-2.28-5.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 74691
     checksum: sha256:799c6cca489942f0c79b50d749d4b4b7aec7e8272b11ee9f7aa3e90d88e5a01b
     name: perl-Compress-Bzip2
     evr: 2.28-5.el9
     sourcerpm: perl-Compress-Bzip2-2.28-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 38610
     checksum: sha256:3b007ee0457d21868c77c8f003403e17eeabb668aadbc6d25575203f6e9087c8
     name: perl-Compress-Raw-Bzip2
     evr: 2.101-5.el9
     sourcerpm: perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 54793
     checksum: sha256:efe198290b085c6e4eb4cfb426704f1222a4bd1f3cbbecfb636a5fa252ec84b4
     name: perl-Compress-Raw-Lzma
     evr: 2.101-3.el9
     sourcerpm: perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 64690
     checksum: sha256:989520079f36b6281e982ed6de02c8024e5d5696df1fc838eae6b36e74f04805
     name: perl-Compress-Raw-Zlib
     evr: 2.101-5.el9
     sourcerpm: perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Config-Extensions-0.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12815
     checksum: sha256:840607ca387a3076f9ee0f40060f6a2b559779ec2a4647e073a5e24fc713e36f
     name: perl-Config-Extensions
     evr: 0.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Config-Perl-V-0.33-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24943
     checksum: sha256:7ec321ecb6f37b6be09ad182cb66fdeee9f12138f75fc48858bde2177c358d1d
     name: perl-Config-Perl-V
     evr: 0.33-4.el9
     sourcerpm: perl-Config-Perl-V-0.33-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DBM_Filter-0.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 35000
     checksum: sha256:b5dbe5adabdd6602224ee8178743b4f34b80d585ab838cb3ad1f2cae99b0e9dc
     name: perl-DBM_Filter
     evr: 0.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DB_File-1.855-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 85113
     checksum: sha256:2cbdfb8cfd2375744b39383311a5e6b590b0773c71eb5bb4f14b3cfcce70eb87
     name: perl-DB_File
     evr: 1.855-4.el9
     sourcerpm: perl-DB_File-1.855-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 58773
     checksum: sha256:0ac738aff66419ff8853d2e2b8d2fe231b90de129060ecc0390bca9c6c680e0d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-OptList-0.110-17.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 30694
     checksum: sha256:1455a3e90116f504008f8d27db57acb65c3389440dc6e2d605f54bf40b009a10
     name: perl-Data-OptList
     evr: 0.110-17.el9
     sourcerpm: perl-Data-OptList-0.110-17.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Data-Section-0.200007-14.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 28030
     checksum: sha256:9fb57b4fbcfea93de114505082261abd97f576cf78e1a205c255d69d8eb6babf
     name: perl-Data-Section
     evr: 0.200007-14.el9
     sourcerpm: perl-Data-Section-0.200007-14.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-PPPort-3.62-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 217292
     checksum: sha256:b9391222f4cef0811b4e99c73b03c22b19fdb99ea4959bbd412fdb2f6fd627d0
     name: perl-Devel-PPPort
     evr: 3.62-4.el9
     sourcerpm: perl-Devel-PPPort-3.62-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-Peek-1.28-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 33702
     checksum: sha256:be10c8ee3eb16d0e81f6a8e4eeda142a56847753f4da2ad4df1237a97518e8bd
     name: perl-Devel-Peek
     evr: 1.28-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-SelfStubber-1.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14932
     checksum: sha256:5b39f719f3e1da497d92b87d597269686925bf08006f8e2c1c92ec0bb8cd9482
     name: perl-Devel-SelfStubber
     evr: 1.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Devel-Size-0.83-10.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 34781
     checksum: sha256:736d3ec0babbdea08633d4bd4bd9121e906e916eb5ac5527d093814a9925c57d
     name: perl-Devel-Size
     evr: 0.83-10.el9
     sourcerpm: perl-Devel-Size-0.83-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 40515
     checksum: sha256:6eeb8e68cfbd7cca24d6132be8b947de99ab26cdb79d6021e9e6efeb36b67e0b
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-SHA-6.02-461.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 67396
     checksum: sha256:ed614bb03e34d4bf5b87de4fc9051911bf2e6080921cdaece18e3f826e6b1319
     name: perl-Digest-SHA
     evr: 1:6.02-461.el9
     sourcerpm: perl-Digest-SHA-6.02-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Digest-SHA1-2.13-34.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 57513
     checksum: sha256:59ecc753d4548f1530d4951475df7f4c703c12519e9488988d1e35b618e79db4
     name: perl-Digest-SHA1
     evr: 2.13-34.el9
     sourcerpm: perl-Digest-SHA1-2.13-34.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DirHandle-1.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12799
     checksum: sha256:b50fdd94649f82218308bd6d0ba5d6e20f658d6fc448aaa1327398443dfaefc7
     name: perl-DirHandle
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Dumpvalue-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18822
     checksum: sha256:60e541f90705e444171f50078c0f1137fcff5576124cbb729768a99386e2016d
     name: perl-Dumpvalue
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26374
     checksum: sha256:38bf98dd2b3e6030058fb3a358e82753da85de8d8a6ad58f7502344444fac451
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1825541
     checksum: sha256:72c92a12c67d05f9aa7f5670ccb1b743612d8fa946775feada28e199a31db0a9
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-Locale-1.05-21.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21500
     checksum: sha256:58afacf30f4a476f4ba6646a6419122d2a729bd59880611b631527502dcdc269
     name: perl-Encode-Locale
     evr: 1.05-21.el9
     sourcerpm: perl-Encode-Locale-1.05-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Encode-devel-3.08-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 45137
     checksum: sha256:bc3e56fb27a8e5947e2fc4bb705c06b10f1dcab42f411cd300e2137ad8f07b35
     name: perl-Encode-devel
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-English-1.11-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13988
     checksum: sha256:51234583bb690fe57ac54a9efca0e4ab51e75f1ad6133e9e1b579b9f851b6575
     name: perl-English
     evr: 1.11-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Env-1.04-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22160
     checksum: sha256:92fb2287084a3c88a6b2d2bd300d1279251cec59156c1a9a3e0fa8fda6c546b2
     name: perl-Env
     evr: 1.04-460.el9
     sourcerpm: perl-Env-1.04-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15285
     checksum: sha256:12b6bcda3a1fdb139e09ef44887a3e068fcdd42afaf9dd4c82b12a8aa3e74724
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 54624
     checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
     name: perl-ExtUtils-CBuilder
     evr: 1:0.280236-4.el9
     sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16489
     checksum: sha256:642338ff95d94e2c6e4b7de47cda7b772d1fbc204b2869925bd0326fcc4b0e26
     name: perl-ExtUtils-Command
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Constant-0.25-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 49788
     checksum: sha256:49aa4d69ad3bfbc05da33c2c88eb82815c76c7b605831012fbed054d9fe2ceb5
     name: perl-ExtUtils-Constant
     evr: 0.25-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Embed-1.35-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18371
     checksum: sha256:cfa0a13f9d7f2b99c40d17f77b03460ef765c5e046c69d46efe057e42d988f33
     name: perl-ExtUtils-Embed
     evr: 1.35-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Install-2.20-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 48441
     checksum: sha256:2533a1d97d45dc79c07cc51409c34f188c042757a2811b04dc16892ae2c7443e
     name: perl-ExtUtils-Install
     evr: 2.20-4.el9
     sourcerpm: perl-ExtUtils-Install-2.20-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-MM-Utils-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14176
     checksum: sha256:51d7199c10886580e6cbff82546a34f26b2d5b894dcc338e28b1b55938f50ae3
     name: perl-ExtUtils-MM-Utils
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 311769
     checksum: sha256:2286e5004cb6436b7ac8dd436c91b4e1d36c18b9385d07a24fc167c930c9dee8
     name: perl-ExtUtils-MakeMaker
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 37829
     checksum: sha256:f7cf7fd259fb8a6c27537dc98e1ed4923b26c2d8d8fd6b789e166ac104cac5bc
     name: perl-ExtUtils-Manifest
     evr: 1:1.73-4.el9
     sourcerpm: perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-Miniperl-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15866
     checksum: sha256:15a90a1f4c0b11048633e996d9887b83db8a48031e1ba2560e72573c328c4cf5
     name: perl-ExtUtils-Miniperl
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 194711
     checksum: sha256:bb7e4bcfe24371bbe202a9fa704360a7bbc5d9f4103ec36e6e571da6eb76a186
     name: perl-ExtUtils-ParseXS
     evr: 1:3.40-460.el9
     sourcerpm: perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21959
     checksum: sha256:6a4cfcc9fc505983315f543068fdb83b3dc13aada8b2da9a41fa049bc4f0ac09
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Compare-1.100.600-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13854
     checksum: sha256:2108ae5f9e3edf870a30a717b6cf999be70b36e50b715b02d5256cdf07f91764
     name: perl-File-Compare
     evr: 1.100.600-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Copy-2.34-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 20838
     checksum: sha256:d547160cfc5e02e3381116185cc5c125c680c2fab6ab7e6696fd95b8e4fdbb4a
     name: perl-File-Copy
     evr: 2.34-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-DosGlob-1.12-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21626
     checksum: sha256:def55d6b10e7ac594a08cf481e4f94819cccac58a0ce9643ede0c041c2ee1e47
     name: perl-File-DosGlob
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Fetch-1.00-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 33372
     checksum: sha256:8c46735b0f703cd53fbaf915423b63baf98701d81406b30b84e42e53a0efbb6e
     name: perl-File-Fetch
     evr: 1.00-4.el9
     sourcerpm: perl-File-Fetch-1.00-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-HomeDir-1.006-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 65857
     checksum: sha256:68f539b86abb7ab910286188ad3742f4338330f3246f6da07cb4ca5c83d8e80f
     name: perl-File-HomeDir
     evr: 1.006-4.el9
     sourcerpm: perl-File-HomeDir-1.006-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-Which-1.23-10.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24163
     checksum: sha256:80a41f9f823312dca2c9fed97f6568a88957572277b75920fb76f20a60902e7f
     name: perl-File-Which
     evr: 1.23-10.el9
     sourcerpm: perl-File-Which-1.23-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FileCache-1.10-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15108
     checksum: sha256:1da22e9c110f143c1dfbd827fefcac6ad514d6bedddb6d3d4152206e0abfc886
     name: perl-FileCache
     evr: 1.10-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Filter-1.60-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 97366
     checksum: sha256:723bcc532676617221a0720fb91feeea644bde3b413a38c16e287cc36ace166f
     name: perl-Filter
     evr: 2:1.60-4.el9
     sourcerpm: perl-Filter-1.60-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Filter-Simple-0.96-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29899
     checksum: sha256:080a1c4c16acddca179c0e2ab8120fe01e374bb86d0a950923a610e50fabfc00
     name: perl-Filter-Simple
     evr: 0.96-460.el9
     sourcerpm: perl-Filter-Simple-0.96-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-FindBin-1.51-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14336
     checksum: sha256:43ef0a61ba09f0213bf7eaf3af905d98b4879fa3e383f1340cad23de1ae46f67
     name: perl-FindBin
     evr: 1.51-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-GDBM_File-1.18-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 23392
     checksum: sha256:556ba46b4328d134763581c0326ae66b8ecea1820979b141da04776c748e9c56
     name: perl-GDBM_File
     evr: 1.18-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Hash-Util-0.23-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 36502
     checksum: sha256:22a67af16177f44a9f7cf72ecdac874561098b8d2ef724678ecde0b2ddf1c465
     name: perl-Hash-Util
     evr: 0.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Hash-Util-FieldHash-1.20-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 40872
     checksum: sha256:5f0699929f103fd1210beb5666528b7bc67f0d72b80fb16afbb1bfc1812f4c9c
     name: perl-Hash-Util-FieldHash
     evr: 1.20-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-Collate-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14785
     checksum: sha256:440007c7d78ddc63839ff9bfe8b82acbd939452f3ada8a1b34288aabd2865150
     name: perl-I18N-Collate
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-LangTags-0.44-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 57020
     checksum: sha256:5812d857fdf616511fc9f4b7ed463f9e3126d85166d56bdd7c7a64d8c2db41bb
     name: perl-I18N-LangTags
     evr: 0.44-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-I18N-Langinfo-0.19-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24519
     checksum: sha256:5a154539ebad7606938fe3eecab53f5b327678bbe4fbe68c91a85a7cfd314373
     name: perl-I18N-Langinfo
     evr: 0.19-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-1.43-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 94579
     checksum: sha256:be88a2f06f958b9ce3d407c8db3833de0766eb998a06eedab4670db9878e061e
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Compress-2.102-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 280708
     checksum: sha256:ce8f2004395442fe663cb9efc56f9af2102c75d746f2ce393e40af8a26ac6871
     name: perl-IO-Compress
     evr: 2.102-4.el9
     sourcerpm: perl-IO-Compress-2.102-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 84153
     checksum: sha256:bda4c005c09e886ce2273a3f418f0cd92521ed0b8fdcdaca7b9fc0026f2a6c7b
     name: perl-IO-Compress-Lzma
     evr: 2.101-4.el9
     sourcerpm: perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IO-Zlib-1.11-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21809
     checksum: sha256:87d7b757a570fb53d72b2dd29558c2b4a8ff33196a80ad10f76999325acaec07
     name: perl-IO-Zlib
     evr: 1:1.11-4.el9
     sourcerpm: perl-IO-Zlib-1.11-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-Cmd-1.04-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 42803
     checksum: sha256:353b04bed7229ce354a4d63ba213c4e18fe739c4732061957946b84853d5b3ce
     name: perl-IPC-Cmd
     evr: 2:1.04-461.el9
     sourcerpm: perl-IPC-Cmd-1.04-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-SysV-2.09-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 48827
     checksum: sha256:4b33d8a7c5ae11c075ca84de9aa2ba5c74e5a021f9e69ddee1093e6b1970815c
     name: perl-IPC-SysV
     evr: 2.09-4.el9
     sourcerpm: perl-IPC-SysV-2.09-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-IPC-System-Simple-1.30-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 44255
     checksum: sha256:35792b1aa241cb17b881b1e44940bc295329a575a2a2d183757ef1d757062465
     name: perl-IPC-System-Simple
     evr: 1.30-6.el9
     sourcerpm: perl-IPC-System-Simple-1.30-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Importer-0.026-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 42526
     checksum: sha256:1afb9008ad841ba4fc207af8ec814d06bd78e958cd2b03089c7b82c71a311060
     name: perl-Importer
     evr: 0.026-4.el9
     sourcerpm: perl-Importer-0.026-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-JSON-PP-4.06-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 70596
     checksum: sha256:17f547d40976904eb59449f0cdec890e34632a28a083fc46157ac1c67e9e3494
     name: perl-JSON-PP
     evr: 1:4.06-4.el9
     sourcerpm: perl-JSON-PP-4.06-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Locale-Maketext-1.29-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 101003
     checksum: sha256:97cfef112a414049f85495cbec570b8c63d7260410f72cb2e1480a67fc7e9e68
     name: perl-Locale-Maketext
     evr: 1.29-461.el9
     sourcerpm: perl-Locale-Maketext-1.29-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Locale-Maketext-Simple-0.21-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18568
     checksum: sha256:20fd5bd35208c94b669179c7e6a295a6fe6abee69e0ce284e0ab25562bcff9c3
     name: perl-Locale-Maketext-Simple
     evr: 1:0.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 35080
     checksum: sha256:8fd71ba1ada7ab6b0b83400716671139a7adbf01d9bfed881398497170ccb308
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MIME-Charset-1.012.2-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 54488
     checksum: sha256:cf481c2178bc2a55c5b455749f38f4f96ee71f32dcf458c34d4f1bbcb996feca
     name: perl-MIME-Charset
     evr: 1.012.2-15.el9
     sourcerpm: perl-MIME-Charset-1.012.2-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-MRO-Compat-0.13-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22804
     checksum: sha256:7921d8fd6d4dacdfb4a286fe4355516f20d660681abb49af9983f7527429e351
     name: perl-MRO-Compat
     evr: 0.13-15.el9
     sourcerpm: perl-MRO-Compat-0.13-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 198900
     checksum: sha256:b90555cc3da95e314e931de2348d7c89da7c16023fb9399cdfbbcf9f1aeade7d
     name: perl-Math-BigInt
     evr: 1:1.9998.18-460.el9
     sourcerpm: perl-Math-BigInt-1.9998.18-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 32494
     checksum: sha256:20b48aa36f522ccc9047fa01cb665ef20ae6a48f1b3a289e37481c159655e5b6
     name: perl-Math-BigInt-FastCalc
     evr: 0.500.900-460.el9
     sourcerpm: perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-BigRat-0.2614-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 42414
     checksum: sha256:c31888896769451095c352ea97a1c88e2bbbc27d5bdc1e018dc8bae680967fb0
     name: perl-Math-BigRat
     evr: 0.2614-460.el9
     sourcerpm: perl-Math-BigRat-0.2614-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Math-Complex-1.59-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 48567
     checksum: sha256:f53531125d6df72f4b50be888b7c3352a4032a5207a7bad774a2658b46d4edad
     name: perl-Math-Complex
     evr: 1.59-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Memoize-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 61549
     checksum: sha256:8ca298bbaff33a951e338d0213560610bd06cf5a3783bb83c34318e9d91b5a72
     name: perl-Memoize
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Build-0.42.31-9.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 274094
     checksum: sha256:9e33e1a46048d262ebe06f98c6c7b1579cdf92db57b0bb4228d13883c232d82c
     name: perl-Module-Build
     evr: 2:0.42.31-9.el9
     sourcerpm: perl-Module-Build-0.42.31-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-CoreList-5.20210320-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 86597
     checksum: sha256:f495039e4a0f025576e5469adc82d12419d8e843325f801cd6bfe80315c239f1
     name: perl-Module-CoreList
     evr: 1:5.20210320-3.el9
     sourcerpm: perl-Module-CoreList-5.20210320-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-CoreList-tools-5.20210320-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 20685
     checksum: sha256:7307f9abaec98de60cd8d1d1fc2820485323d7152c256356735890b0755f6e4e
     name: perl-Module-CoreList-tools
     evr: 1:5.20210320-3.el9
     sourcerpm: perl-Module-CoreList-5.20210320-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Load-0.36-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 20052
     checksum: sha256:ada066ac44fd73ec87ea376a6d6715cf77b086354217fdc7a197c909da3bb099
     name: perl-Module-Load
     evr: 1:0.36-4.el9
     sourcerpm: perl-Module-Load-0.36-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25464
     checksum: sha256:58a5364d77607678e4e628f5bdd3d33641e2f6083c2985c1bc5045401ae65a60
     name: perl-Module-Load-Conditional
     evr: 0.74-4.el9
     sourcerpm: perl-Module-Load-Conditional-0.74-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Loaded-0.08-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13935
     checksum: sha256:6651d40ae9a673262240d750f1b4236eb8db8f9a4a81ff3d529be1e65ea0a098
     name: perl-Module-Loaded
     evr: 1:0.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Metadata-1.000037-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 39221
     checksum: sha256:f053b34c911e5f3daf16c0ffc5ff752f47a0d016e1cc1ac51d4425fbe2a1ac15
     name: perl-Module-Metadata
     evr: 1.000037-460.el9
     sourcerpm: perl-Module-Metadata-1.000037-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Module-Signature-0.88-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 89282
     checksum: sha256:1a173631124cdb77ffa2cb11ceb8de813f6e4222e5bf9ae657947211480858e6
     name: perl-Module-Signature
     evr: 0.88-1.el9
     sourcerpm: perl-Module-Signature-0.88-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 23492
     checksum: sha256:ab4a9be46c64b83524f9b5169d88f025c22ecefb37d81f2e8c13df134c7158c4
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-NEXT-0.67-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21511
     checksum: sha256:85c96161deaf2161fbe1f0d6e46e57d78c5fb839301c94d0782f400066455326
     name: perl-NEXT
     evr: 0.67-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 27619
     checksum: sha256:79168b438837b36fb8abd5184859651788604c116be0d271fa633276a69662a5
     name: perl-Net
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-Ping-2.74-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 53027
     checksum: sha256:fb74fb2651f62421538bb05992af5251887013a72c4412f5c2421992204c03bc
     name: perl-Net-Ping
     evr: 2.74-5.el9
     sourcerpm: perl-Net-Ping-2.74-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 429301
     checksum: sha256:8f46470e0e2a76d1f534b8d0d607d84a64ebfab3df8347bae2d52d113c8d54eb
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ODBM_File-1.16-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 23502
     checksum: sha256:792cb71a1f952667c302e5f09fb3e52b73bee4c8e228c1f443e841fa78f1948b
     name: perl-ODBM_File
     evr: 1.16-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Object-HashBase-0.009-7.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 28938
     checksum: sha256:2144d4c29ea4acfc0d872bf09cb4d9dce14a64e60a45633f1a31ed3a2b125ee8
     name: perl-Object-HashBase
     evr: 0.009-7.el9
     sourcerpm: perl-Object-HashBase-0.009-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Opcode-1.48-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 38446
     checksum: sha256:6dab3414d70e61531edacf0ec9386c19d8c2e052f4475bea77b01d95b805e0f5
     name: perl-Opcode
     evr: 1.48-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 100314
     checksum: sha256:3b83ed6478d8f143547f9ecd284b3139d6f25698cc4466729a55b0d8a3b9ac9e
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Package-Generator-1.106-23.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26822
     checksum: sha256:2c9b4699185c30d1da293add16911555e93b7532d77e59aa07e2c9c8d8eafcf3
     name: perl-Package-Generator
     evr: 1.106-23.el9
     sourcerpm: perl-Package-Generator-1.106-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Params-Check-0.38-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24764
     checksum: sha256:a6cf1009e3f1dfe50e00421b11d43c413e7e4ee8c6931195256a3cb40e1baf7b
     name: perl-Params-Check
     evr: 1:0.38-461.el9
     sourcerpm: perl-Params-Check-0.38-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Params-Util-1.102-5.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 38447
     checksum: sha256:e8219eff046c4d85aeaf4581037b8e3aea3db9fd56bf648d84588fbd5b27123a
     name: perl-Params-Util
     evr: 1.102-5.el9
     sourcerpm: perl-Params-Util-1.102-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 94325
     checksum: sha256:5cd800158be7a9ddaf8e9c5d193d10992e01a35c4f438ff072852d194e3a5311
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Perl-OSType-1.010-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26284
     checksum: sha256:64f37a98e22fce4ee9520da6db13ab601e21e34ac9d3ae7f85fc7a63761c492b
     name: perl-Perl-OSType
     evr: 1.010-461.el9
     sourcerpm: perl-Perl-OSType-1.010-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25566
     checksum: sha256:31d1284cda8a84f78574ae2380474412788de756613bcb11a85d68c94af9ba0b
     name: perl-PerlIO-via-QuotedPrint
     evr: 0.09-4.el9
     sourcerpm: perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Checker-1.74-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 35171
     checksum: sha256:7410aed54bb1c0a18b7b0ec33b6067475383b557defdd295b48b3277229d31a1
     name: perl-Pod-Checker
     evr: 4:1.74-4.el9
     sourcerpm: perl-Pod-Checker-1.74-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Functions-1.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13990
     checksum: sha256:b843dc0a066b663fd00312a2355f0b512b84906a34bbeb1946bcfd9d0f85ce3d
     name: perl-Pod-Functions
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Html-1.25-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 28371
     checksum: sha256:8275355aecc93d59cf27acfa23cc8567b5a9aff8dff0cc60a446f65643638464
     name: perl-Pod-Html
     evr: 1.25-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Safe-2.41-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25655
     checksum: sha256:6b4297166c836f624884960f3fd6627dab8238e8665fd660d7fb97287743a16d
     name: perl-Safe
     evr: 2.41-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 76001
     checksum: sha256:5e3592356c1610311f5bf8be4cbc9e35ad04d6b3ba089d70b700d8b70f534635
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Search-Dict-1.07-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13596
     checksum: sha256:867c49e05a2766e22fd09d86b777dd3f97d36b40057f63f360b9f278549f521e
     name: perl-Search-Dict
     evr: 1.07-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-SelfLoader-1.26-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 22204
     checksum: sha256:e8d612dcd47d9769dd1502b92ec7606c195273aa9d61ab13c7bc5e7a07359bb3
     name: perl-SelfLoader
     evr: 1.26-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 59426
     checksum: sha256:f69c6cd2c48606efa7477ef73ef2cb03c07aa02d535f03824dbe966f6235cc88
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Software-License-0.103014-12.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 147494
     checksum: sha256:c225b78b513fc8b90a0b2b773fadcf65dd2defe2a147fca67c52971d2750f437
     name: perl-Software-License
     evr: 0.103014-12.el9
     sourcerpm: perl-Software-License-0.103014-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 98115
     checksum: sha256:61a7bc7d2a2e3b0c42289927a1ecc7b9f672ce3281be58a59b3b2875e4203457
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sub-Exporter-0.987-27.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 78523
     checksum: sha256:4e2535cd4d456f91f346e6d690c9a22c4b2a01318f9a5b5f761e1170d815bed1
     name: perl-Sub-Exporter
     evr: 0.987-27.el9
     sourcerpm: perl-Sub-Exporter-0.987-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sub-Install-0.928-28.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25233
     checksum: sha256:4ce03d243d1331188c5a2b0e4103dad6b930ba36362cd353f0f3cd0998784e82
     name: perl-Sub-Install
     evr: 0.928-28.el9
     sourcerpm: perl-Sub-Install-0.928-28.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sys-Hostname-1.23-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 19074
     checksum: sha256:e899e5a9f4624407464920c3b11a4e44ea4eb8996da8a76236aff3c057bc2c11
     name: perl-Sys-Hostname
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Sys-Syslog-0.36-461.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 52646
     checksum: sha256:ec4ca7f72dff339eed3d7878ec86af177cf6d21402a002558142173eabf3c9ec
     name: perl-Sys-Syslog
     evr: 0.36-461.el9
     sourcerpm: perl-Sys-Syslog-0.36-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Complete-1.403-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13574
     checksum: sha256:1d500a1e9dad3d67fff08ac6a7219152a9082f7a92893cfb653171ab198f5e79
     name: perl-Term-Complete
     evr: 1.403-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-ReadLine-1.17-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 19755
     checksum: sha256:2cc16944420d5b8a3318982fc063e4ea2f3d387e1a255d8d08a15f839d8204ff
     name: perl-Term-ReadLine
     evr: 1.17-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Size-Any-0.002-35.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16309
     checksum: sha256:e83c29bb60e3fdac1c7aa5d3cde8a6b237812a14fe8f711bf6e127ed96d929a4
     name: perl-Term-Size-Any
     evr: 0.002-35.el9
     sourcerpm: perl-Term-Size-Any-0.002-35.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Size-Perl-0.031-12.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25142
     checksum: sha256:0acd3a4bd0f98b24701f88a6853ba39f11c490fa816e44e7209690d23960cfbf
     name: perl-Term-Size-Perl
     evr: 0.031-12.el9
     sourcerpm: perl-Term-Size-Perl-0.031-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Term-Table-0.015-8.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 40852
     checksum: sha256:3e0c26e1b0e31d17cc133829ad8d6e22c86e532e9b6a3c26f48b7ec447bdfbb4
     name: perl-Term-Table
     evr: 0.015-8.el9
     sourcerpm: perl-Term-Table-0.015-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 40577
     checksum: sha256:bfe0d10d4c1028a7929ca213bfd3871f059ea0daeec4c48f3e85d54d77a5a2fc
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-1.31-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29295
     checksum: sha256:5c8c76bc8d054ae19574fb973541cedf9e56f92c79424a86219e4c1eb65b3227
     name: perl-Test
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-Harness-3.42-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 306138
     checksum: sha256:7980ae9e28aed0aadef4f169e8479812a2a6bacf05ee53001f63d021b065fe40
     name: perl-Test-Harness
     evr: 1:3.42-461.el9
     sourcerpm: perl-Test-Harness-3.42-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Test-Simple-1.302183-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 645034
     checksum: sha256:04ae40e07d57934e5dc3946fa638023ee76305dac04bed7813ed338b0a4c2ef2
     name: perl-Test-Simple
     evr: 3:1.302183-4.el9
     sourcerpm: perl-Test-Simple-1.302183-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Abbrev-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12713
     checksum: sha256:b172427e49212833e48b699190ad0d34432c102478e869f4974a3f323d0fa375
     name: perl-Text-Abbrev
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Balanced-2.04-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 51500
     checksum: sha256:67ff60f60b6dc900e840ed51ff3b1cabef9e43aa48cba81ad97ae9423bdca5af
     name: perl-Text-Balanced
     evr: 2.04-4.el9
     sourcerpm: perl-Text-Balanced-2.04-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Diff-1.45-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 45523
     checksum: sha256:5141fc840dc2989b44df904df2cadfdc3b6b9d38a7e4dba2c2db3c14e3dbc060
     name: perl-Text-Diff
     evr: 1.45-13.el9
     sourcerpm: perl-Text-Diff-1.45-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Glob-0.11-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15921
     checksum: sha256:079d5eb4a606a131eaeecfcbd7f7d39a21c9c49b97bd6b84f7d08986dd11dc59
     name: perl-Text-Glob
     evr: 0.11-15.el9
     sourcerpm: perl-Text-Glob-0.11-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Text-Template-1.59-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 64485
     checksum: sha256:3c7350777e9d26fe4c02d52e8c4d4e0643ee32f8abfb9e22fc28f5325702924e
     name: perl-Text-Template
     evr: 1.59-5.el9
     sourcerpm: perl-Text-Template-1.59-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-3.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18516
     checksum: sha256:b1f3ce55b43fd98a9d445cc4bb522d60adcc3fa42944641448684d2f8c24077e
     name: perl-Thread
     evr: 3.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-Queue-3.14-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24804
     checksum: sha256:88d838d681ad683970eb8566e8936faabffc3495dd1b555f083a1cd00538291a
     name: perl-Thread-Queue
     evr: 3.14-460.el9
     sourcerpm: perl-Thread-Queue-3.14-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Thread-Semaphore-2.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16298
     checksum: sha256:92f0836359ffea1017fce7dca7d4ca3555e42e38690c21dc92efdd9a6f6110b2
     name: perl-Thread-Semaphore
     evr: 2.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-4.6-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 34318
     checksum: sha256:90cd8a8c7c31137b4f7ed03b1533ab79f88d3c4977e2e795525d5e4ead55212a
     name: perl-Tie
     evr: 4.6-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-File-1.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 44505
     checksum: sha256:20fb32eeec0d12f37716a9f955c64305ab14a2ca53b18def3268125b102f318d
     name: perl-Tie-File
     evr: 1.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-Memoize-1.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14721
     checksum: sha256:dfec0d0452c982fa468f3e68ea24239ec9588b6202bb9fe4b1356780baeeca4f
     name: perl-Tie-Memoize
     evr: 1.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Tie-RefHash-1.40-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 26260
     checksum: sha256:5519a86c145d83a1633a127f7b0b6a371e6b2b8a647dabff45c2754388504a44
     name: perl-Tie-RefHash
     evr: 1.40-4.el9
     sourcerpm: perl-Tie-RefHash-1.40-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 20249
     checksum: sha256:0f9b8228482876a79e8369500b750ea0047f2ac715fa40a41b794ef6026292f3
     name: perl-Time
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-HiRes-1.9764-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 62449
     checksum: sha256:87390bc4f89cd00517fbed954004f851334dc081e9cbf679ed8f9cc75f02c531
     name: perl-Time-HiRes
     evr: 4:1.9764-462.el9
     sourcerpm: perl-Time-HiRes-1.9764-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Time-Piece-1.3401-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 43342
     checksum: sha256:9a186bc9fd53bbafdca09e59f4d94cbb32c6338b232a56405ef4124791ca8d48
     name: perl-Time-Piece
     evr: 1.3401-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-Collate-1.29-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 761716
     checksum: sha256:c21e4ffbdb9e9bd3b3c297b059bedd421ab458a3ec7970b93e5e30914006f2d9
     name: perl-Unicode-Collate
     evr: 1.29-4.el9
     sourcerpm: perl-Unicode-Collate-1.29-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 132417
     checksum: sha256:7b0786e7b16f27ee07070c31e6ab17fd4474c327e5d94185c34849f1a57d432d
     name: perl-Unicode-LineBreak
     evr: 2019.001-11.el9
     sourcerpm: perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-Normalize-1.27-461.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 92474
     checksum: sha256:7ca97e263d79d5a0e5f2093c54bcb73399532562e5bd15b30f1762cf8b1c3359
     name: perl-Unicode-Normalize
     evr: 1.27-461.el9
     sourcerpm: perl-Unicode-Normalize-1.27-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-Unicode-UCD-0.75-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 80630
     checksum: sha256:72dddc4fff3d829ab7b7e5f32dbc027f26f772ffa8f0274224b1cba1d47a778e
     name: perl-Unicode-UCD
     evr: 0.75-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-User-pwent-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 21758
     checksum: sha256:27f572e65b4e0b777c5fe567483f774b4e1c1200ec225e5d817c452812858842
     name: perl-User-pwent
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-autodie-2.34-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 103286
     checksum: sha256:8c4a7c8fd5074801946cce0b0b2f47337036e7f64e4cb9c833d9cf1de1f14edc
     name: perl-autodie
     evr: 2.34-4.el9
     sourcerpm: perl-autodie-2.34-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-autouse-1.11-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14134
     checksum: sha256:b165ef7e5bb8a2b898bbe2b88fe35bc005ef77a5ccf006b055448dc9bed17040
     name: perl-autouse
     evr: 1.11-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-bignum-0.51-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 48635
     checksum: sha256:a25963adbb78901e2581a041252bfc96f55e534403e4af513d8728c62f0b4800
     name: perl-bignum
     evr: 0.51-460.el9
     sourcerpm: perl-bignum-0.51-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-blib-1.07-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 12768
     checksum: sha256:de430b1a162b99600aa6e1def89526c266d7a45d2a0985888859098d06ef4f0e
     name: perl-blib
     evr: 1.07-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-debugger-1.56-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 138187
     checksum: sha256:98fe7aa5a1d244e7f61145396cdf6f9248c5f61416ba9bbd1e6cecd0800b52b5
     name: perl-debugger
     evr: 1.56-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-deprecate-0.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14963
     checksum: sha256:4a233b89a6a942448705a26eaa555398d7bc64e710d8a78150f4a96b2207abc8
     name: perl-deprecate
     evr: 0.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-devel-5.32.1-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 696266
     checksum: sha256:60599c65a9a0d77dedcddc184e1e3f3b4f95409928a02a16114bc217df807824
     name: perl-devel
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-diagnostics-1.37-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 216999
     checksum: sha256:c5beafc6150251bb39d8bd19b30cc658b604603e9244aeccb9d747fae73fab5d
     name: perl-diagnostics
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-doc-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 4804041
     checksum: sha256:a107369e340680c1229420021f9b9bf06699efceb6c31197fd870fccb2a12dd6
     name: perl-doc
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-encoding-3.00-462.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 65958
     checksum: sha256:43b1c0c7e7f6029f5610355e2fdea3fb8c6fa1cc956331f53a8b7d4bb8bb65e4
     name: perl-encoding
     evr: 4:3.00-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-encoding-warnings-0.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 17234
     checksum: sha256:4db8e5730e9135e68ee10c0d5f8ca2095cfc5f2b548febe6aad2caaba61d8921
     name: perl-encoding-warnings
     evr: 0.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-experimental-0.022-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 24376
     checksum: sha256:ae48d202863aba2573c70d803a9931de4e3c4b0d3e4f2df561bcc1bf78dc7920
     name: perl-experimental
     evr: 0.022-6.el9
     sourcerpm: perl-experimental-0.022-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-fields-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16577
     checksum: sha256:25f2bce872cdd91240c5a42b0ee6990db0b51bb51bdcee6fa441aa4889b9bd84
     name: perl-fields
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-filetest-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15022
     checksum: sha256:3ba9775352bcb0aa76a6321ce582f028f23223743eecfdcd8458da05636f8436
     name: perl-filetest
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-inc-latest-0.500-20.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 27665
     checksum: sha256:22c41d7117656dfff8d52bc8e557e6f8d11d2b5ed377173f56037a2ac8bc9139
     name: perl-inc-latest
     evr: 2:0.500-20.el9
     sourcerpm: perl-inc-latest-0.500-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 74626
     checksum: sha256:676044af96202c9ed74003323f3d1fbb76a46dc82c0eeb5382fe03870b3aff8f
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-less-0.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13545
     checksum: sha256:268da168b25a97a8be8c736217a60e12ea54b0a67261cf7dd8199297a3dd10e3
     name: perl-less
     evr: 0.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-lib-0.65-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 15272
     checksum: sha256:86725f96c996c2db85324e939da020c7e587570ecf1f541e9ad38dee984419b3
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libnetcfg-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16729
     checksum: sha256:c9e9bbf74d825bb623ae797f35b38d31ea03aede18900bcbe624bc95de2c389a
     name: perl-libnetcfg
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 2263056
     checksum: sha256:7a46669305e11ed69be2434badbaede68ccd0b6576ef11bc0cc7c03df6ab658f
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-local-lib-2.000024-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 73510
     checksum: sha256:c8f58afb9e8eb07bc57f92c384753ee4f4fec10fa7ec7c091ad9f15110a10026
     name: perl-local-lib
     evr: 2.000024-13.el9
     sourcerpm: perl-local-lib-2.000024-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-locale-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14021
     checksum: sha256:35930019be1e37fa53b29cc9af6326443a96817024120948ca89556b1db06eda
     name: perl-locale
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-macros-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10809
     checksum: sha256:4afe9e549dcaad11ec3f6ac2d89595b8d8ad37e305f4d70f7de2ec70d1f90ded
     name: perl-macros
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-meta-notation-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9810
     checksum: sha256:a6ce87fee7568af4803818fe9715c3253b5b6401e88c2b20bdc07eec9d664bd2
     name: perl-meta-notation
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-mro-1.23-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 29462
     checksum: sha256:0afcac4067601e057accf67f9cf80b95f441ad1c5260c32864da54da2f83612e
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-open-1.12-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16871
     checksum: sha256:52897741a5e6d526aa0de31438c48aa0f1f40c2fdd15720c4956e79e01830898
     name: perl-open
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-perlfaq-5.20201107-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 388433
     checksum: sha256:6f876ec91543f837fb0a212d0265a12dd0505ca3ee706fca81275e3ab2af79a4
     name: perl-perlfaq
     evr: 5.20201107-4.el9
     sourcerpm: perl-perlfaq-5.20201107-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-ph-5.32.1-481.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 45374
     checksum: sha256:a1539c3b00351282d13a6c480598a80842413f2149063ceee62cbf4ce0c6ea03
     name: perl-ph
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-sigtrap-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 16091
     checksum: sha256:4c42029372306ee2cf559e3b4f899c2170d2088f26b66a0f29ac1d8cb66b5387
     name: perl-sigtrap
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-sort-2.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13868
     checksum: sha256:f4aedfdb824193f1aa0f45ee092e2f887f3734065861a90b4e089a6e1f9cfab1
     name: perl-sort
     evr: 2.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9639
     checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
     name: perl-srpm-macros
     evr: 1-41.el9
     sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-threads-2.25-460.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 61254
     checksum: sha256:787a2ff27e96046c3b38e44a760e52660f6b63875661ef64addde79b63363eb1
     name: perl-threads
     evr: 1:2.25-460.el9
     sourcerpm: perl-threads-2.25-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-threads-shared-1.61-460.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 47910
     checksum: sha256:073ef01a23d905b89b5688645c85fa654567876c19043378b9fd15e44229c558
     name: perl-threads-shared
     evr: 1.61-460.el9
     sourcerpm: perl-threads-shared-1.61-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-utils-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 58445
     checksum: sha256:3af8e12fe87b871c3a4ed52188ff716b8d9b62030d8ecc2c019de7e4a65f2809
     name: perl-utils
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-version-0.99.28-4.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 67978
     checksum: sha256:9b7761fa17fd29d8e6f80cfbf12c659cd90a133f5dfc813881473195e0a2a4ce
     name: perl-version
     evr: 7:0.99.28-4.el9
     sourcerpm: perl-version-0.99.28-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/perl-vmsish-1.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14503
     checksum: sha256:e27e656ae98a4d98e95a9bb6fdeaaae819bf692e8169d8a58ca2e0c564dfe3c9
     name: perl-vmsish
     evr: 1.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 173063
     checksum: sha256:148c080d133bc2d45dab5cd57c830145cd7a53810522e38110abfebbd0f06792
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/pyproject-srpm-macros-1.12.0-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 14645
     checksum: sha256:e19955e05af502a66d28246f083dfeed32cb7cfb56feced5c51b33cde77172b2
     name: pyproject-srpm-macros
     evr: 1.12.0-1.el9
     sourcerpm: pyproject-rpm-macros-1.12.0-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 18705
     checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 10813
     checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
     name: python-unversioned-command
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 9344
     checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
     name: qt5-srpm-macros
     evr: 5.15.9-1.el9
     sourcerpm: qt5-5.15.9-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/redhat-rpm-config-208-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 77229
     checksum: sha256:257cb0ffa77bff30467daa8f3bc8b867c86a6c532af424e86fae595cef6685d5
     name: redhat-rpm-config
     evr: 208-1.el9
     sourcerpm: redhat-rpm-config-208-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 11243
     checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/sombok-2.4.0-16.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 51650
     checksum: sha256:9ff787f7edde5ff05a3e86c55913cbb2ab0d2e38ba5c9a7e318ef621991b3b8b
     name: sombok
     evr: 2.4.0-16.el9
     sourcerpm: sombok-2.4.0-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/sysprof-capture-devel-3.40.1-3.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 66841
     checksum: sha256:47307f58e4707dc31c1bf096e095653aff30837cea5cb4a8820c4c6d57870eb3
     name: sysprof-capture-devel
     evr: 3.40.1-3.el9
     sourcerpm: sysprof-3.40.1-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/s/systemtap-sdt-devel-5.1-4.el9_5.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 78967
     checksum: sha256:cce6b1718e2dc592659e4e40bb47e9ffe61dd984cd99b447e1f997bfdac6ce80
     name: systemtap-sdt-devel
     evr: 5.1-4.el9_5
     sourcerpm: systemtap-5.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/v/vim-common-8.2.2637-21.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 7357129
     checksum: sha256:04f5c52eb37b080fa7725539489ff9fcab8639638b1edabc0defb69e8e77cf4b
     name: vim-common
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/v/vim-enhanced-8.2.2637-21.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 1784371
     checksum: sha256:e8979a9116cf0a628c1a3a3c41f37a89021234f50f7aac235f10dc49ecab66e2
     name: vim-enhanced
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/x/xml-common-0.6.3-58.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 37016
     checksum: sha256:2278e3b1ce7ddd4ff394064e5dc5404ac2799e51f9441a056b334d518bb51af4
     name: xml-common
     evr: 0.6.3-58.el9
     sourcerpm: sgml-common-0.6.3-58.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/x/xorg-x11-proto-devel-2024.1-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 321971
     checksum: sha256:1ad6ee7c810cdacaf1b6d04f09c8a3e38fb14751c3289b800a18127698dc51d9
     name: xorg-x11-proto-devel
     evr: 2024.1-1.el9
     sourcerpm: xorg-x11-proto-devel-2024.1-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/x/xz-devel-5.2.5-8.el9_0.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 60585
     checksum: sha256:6f022d62d571550bf8147357f4ff7ccee60b772e013552f7fb622b5672436663
     name: xz-devel
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/z/zlib-devel-1.2.11-40.el9.aarch64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-aarch64-appstream-rpms
     size: 47965
     checksum: sha256:ec1e974313c06f71a11a0732b9b08ef588e3cc58bd7ee0c02df792a1b196f60b
     name: zlib-devel
     evr: 1.2.11-40.el9
     sourcerpm: zlib-1.2.11-40.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/a/acl-2.3.1-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 77245
     checksum: sha256:59d24711260ff0e69762fc4e728279b0e7b6ecfdb5a9b8ba01cd96682c679022
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-2.35.2-54.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 5032427
     checksum: sha256:a8d027ff813e6701c9d0cd3fb9bf07c7e345f1624bca3ed72569315147b1d3cb
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 904635
     checksum: sha256:89f27c7e17bf4a70f1268e4fa6cfcfc605525b75b56494a94edf4d88ae8561bb
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 100995
     checksum: sha256:6b4e2bae51af42c1ab0f1ec7430ab19542747937a827eba8cac540cb7514a145
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 3821337
     checksum: sha256:c4ef55b06c9b5352b2338a6deccd25030472308b3ffe39735585967382e75419
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-1.12.20-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 8025
     checksum: sha256:5178f638660d1699fb06caeeac91f41c07da59b500e94adf2653df892f2cbdf8
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-broker-28-7.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 173303
     checksum: sha256:342af53fbf4254e34b5f19a6be6f22c67551c26dd0c49016edc93e806621b75d
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/d/diffutils-3.7-12.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 405687
     checksum: sha256:524412f7ce56095508190116cb8ae141737857e4447979330c3cf75ca7017e6b
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 39439
     checksum: sha256:4a3d077128ac04bac610dd9e099da41567f112245378d102f054f124e2d57342
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-default-yama-scope-0.191-4.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 12782
     checksum: sha256:e186f5fb020da75279f726a9a09bfefd8c60131157debd9ca0966036fd3b8d70
     name: elfutils-default-yama-scope
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libelf-0.191-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 214706
     checksum: sha256:d5273cf7dd4a1d0d0c34ae607aecff9125d1551df6a2e516dd5c68c2b0127f06
     name: elfutils-libelf
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/elfutils-libs-0.191-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 265759
     checksum: sha256:2212669ed94097297dac70035a1321d53e9f0a5421d6637c5b9646f6e7a7583d
     name: elfutils-libs
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 116093
     checksum: sha256:74734affbd72263c90faef8ab20297ef5cd5bde7805956029e1f36c60a99e973
     name: expat
     evr: 2.5.0-3.el9_5.1
     sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/file-5.39-16.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 53149
     checksum: sha256:e82e23ca88067aa8d5b5b6adaa7a3500a0eb74e7612de35d1fb6b3b1df940aad
     name: file
     evr: 5.39-16.el9
     sourcerpm: file-5.39-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 564807
     checksum: sha256:158af4d5ecbd8b87f0da762ea1655bd4c86512071a95d8307eda3e0b3991105d
     name: findutils
     evr: 1:4.8.0-7.el9
     sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/freetype-2.10.4-9.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 394775
     checksum: sha256:ac139ca5f1debcc76561dce10757fbabf6f00ca74260ac69eb43e88e6fcffa14
     name: freetype
     evr: 2.10.4-9.el9
     sourcerpm: freetype-2.10.4-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gettext-0.21-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1181385
     checksum: sha256:52f11ec908a17fedbf993ffd87f40f27067761440c433b0d0fd38f16b8d15ec4
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 295874
     checksum: sha256:b503ae5eaa875c8936ac6c28dec058d0febc6ce072c0046028bc471a37607f6a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/glibc-gconv-extra-2.34-125.el9_5.1.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1856775
     checksum: sha256:ce2d0f05b8c3f3429afe114eb6dbc8505c7e7bf8755a1e9890dbf18c870f2936
     name: glibc-gconv-extra
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/graphite2-1.3.14-9.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 96898
     checksum: sha256:40ed9377c2f12b029808dd5d129258d1d8a8c93b5bae75f4eb99566c16161791
     name: graphite2
     evr: 1.3.14-9.el9
     sourcerpm: graphite2-1.3.14-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1088949
     checksum: sha256:452cfe5372c834bb174ef1f6eed4d0aa6179420fd572163467ac9036fc7a3a1d
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 169809
     checksum: sha256:45710df49b439ddc4a2848fd3877367761b574234ae28b6be46f1cf54f3fcdca
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/h/harfbuzz-2.7.4-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 643882
     checksum: sha256:bd3beaac1c0afefcd9f4893a814e79055c257c724c73d3b08aa3d9a32df3dcf4
     name: harfbuzz
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/k/kmod-libs-28-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 65172
     checksum: sha256:034496ce5f4ab068b21e4b53a3cf0845fb126b03fcda430b7e2636812092f460
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/less-590-5.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 169771
     checksum: sha256:07633e451edaf2bfe689d3ee28ddc6e8762dcc7d08a9fbb83246ee4999cf17ba
     name: less
     evr: 590-5.el9
     sourcerpm: less-590-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libaio-0.3.111-13.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 27497
     checksum: sha256:59f83d0fedd13d27e3436834727d9319d419309f0280586d86fb818891818e14
     name: libaio
     evr: 0.3.111-13.el9
     sourcerpm: libaio-0.3.111-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 322936
     checksum: sha256:d0b95c3894f7cfe2be53d79923c14608f6d18d30b5cdddbd4d4c48e75fcbe74a
     name: libbrotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libdb-5.3.28-54.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 727287
     checksum: sha256:1877d6f48fe6dde15df54697259315f687484c367c0cfbaafb12e2a8d1aee026
     name: libdb
     evr: 5.3.28-54.el9
     sourcerpm: libdb-5.3.28-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 29577
     checksum: sha256:b6f435b6b79b8a62729f581edead46542dc61fe7276117b2354c324c44ba8309
     name: libeconf
     evr: 0.4.1-4.el9
     sourcerpm: libeconf-0.4.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 107505
     checksum: sha256:a56a79e2254db3d351dce58e9960921aec45715b6b7c93eb7a0f453d1e60bae4
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libfdisk-2.37.4-20.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 154229
     checksum: sha256:ec79a7d9d7f11de5c2faf036e225f2e749dd32ee05f99490af4f5fdc0b248c80
     name: libfdisk
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 267717
     checksum: sha256:417eeb095770944a0c25551771d9ae2ea367b3c979eba9da8a529957f49bafa5
     name: libgomp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libicu-67.1-9.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 9922543
     checksum: sha256:2d97da343d37692d02063b9243815cea180c64c46c343b7dc704d93b2c3b5a84
     name: libicu
     evr: 67.1-9.el9
     sourcerpm: icu-67.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 38310
     checksum: sha256:9bdfccf6b092e0683aa6984f7c6caa737b30c0b1495e16abb03b5d1a5f8e787a
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpng-1.6.37-12.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 119529
     checksum: sha256:4b5c5f328eb641047d857fbcc026dcdd9db65cd670df15e6bf0f0010990ddd6f
     name: libpng
     evr: 2:1.6.37-12.el9
     sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 125712
     checksum: sha256:1657d94bbd79f93dc7a79d474316813bde681ce3a7f62f73314ec4d630e39349
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 76024
     checksum: sha256:fc1d5e93483d166ca7f2acb50c04c181db2f3e7b89dba8edc6b1e5f2b0f10619
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libselinux-utils-3.6-1.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 198305
     checksum: sha256:8272ab39ab64ab4bde0c5e31387be6e28270a1b1d81a33ba621e6e677b9e974e
     name: libselinux-utils
     evr: 3.6-1.el9
     sourcerpm: libselinux-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 30505
     checksum: sha256:d352371cbb7d5bd0c53fc699df953c8c1f184b056690b3c4571e57a6634015c5
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/m/make-4.3-8.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 550249
     checksum: sha256:351a22b0e6744bd329b1b0f22d9c3b69a6da970b575e6c76190cc84b0fe77450
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 418858
     checksum: sha256:5d646286b1f79fa893c17c50605566682a70d924492b769ae2f288ed9dd30947
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1398689
     checksum: sha256:f914250a9ef52968e27af0f0e2520745df4443dc354367bec54dd06b4a2da60b
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 645036
     checksum: sha256:e3a5a1eeed55a2ed968ba5435c0c172a102b7a37302f96770bb3f4dbb444effd
     name: pam
     evr: 1.5.1-22.el9_5
     sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 45196
     checksum: sha256:aa38a3951a690d721a815ea8f9b01995a85f35a8540d8075205821011d0385e6
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 12398
     checksum: sha256:47f1f744f96a2f3d360bc129837738dcebb1ee5032effc4472a891eea1d6a907
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 251813
     checksum: sha256:81e7f4a37458072b2f0f86bdb36321ea5e30ef114ffb6a4e0a37fb29fd1c99a6
     name: policycoreutils
     evr: 3.6-2.1.el9
     sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 363344
     checksum: sha256:a8c7514beb4c3cafa6341f43bbe285319d863b2893a34d91159dc8e90f615dd2
     name: procps-ng
     evr: 3.3.17-14.el9
     sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 30695
     checksum: sha256:8f4c418c5857bee6cc18b91363f80065e15b7455554fbfe047c04b9d61509376
     name: python3
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 8474536
     checksum: sha256:eecde68582784a716ed9370f9b23ef83483aed3d5adb4f0614386bd27bc22999
     name: python3-libs
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1193706
     checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
     name: python3-pip-wheel
     evr: 21.3.1-1.el9
     sourcerpm: python-pip-21.3.1-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 157800
     checksum: sha256:4c7b1bbabe7f37d1dd098c9d893f7f8e97e5fd43aa8fa4d4c58a3b6b66e69c70
     name: python3-pyparsing
     evr: 2.4.7-9.el9
     sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 480100
     checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
     name: python3-setuptools-wheel
     evr: 53.0.0-13.el9
     sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-34.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 18146
     checksum: sha256:bb716a4730a4d20877aed7ec86e0e95ab70ad91a95b6027ea6a1bbff916c7d05
     name: rpm-plugin-selinux
     evr: 4.16.1.3-34.el9
     sourcerpm: rpm-4.16.1.3-34.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/selinux-policy-38.1.45-3.el9_5.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 52484
     checksum: sha256:217d992f42cab6cae7b0236daeefe78d067f882481f20316198e0736f1325ab2
     name: selinux-policy
     evr: 38.1.45-3.el9_5
     sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/selinux-policy-targeted-38.1.45-3.el9_5.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 7225392
     checksum: sha256:575305a4fc873ef9b1fcaf6005a6f04be6d3ff4a5887d6db8ed97cef23c501c5
     name: selinux-policy-targeted
     evr: 38.1.45-3.el9_5
     sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-252-46.el9_5.2.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 4180924
     checksum: sha256:bdfdac1d4db33f415c901d1e8e994e193c1249600da0f6822123d65b378d0edc
     name: systemd
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-pam-252-46.el9_5.2.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 283181
     checksum: sha256:6e0d748b0990c13092a9743b2b6f6f41ac305f46a4bf39100b606187ce0bf0f5
     name: systemd-pam
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/s/systemd-rpm-macros-252-46.el9_5.2.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 76871
     checksum: sha256:e7805025edd419b440dfc3948201b0ef1dee7e2f51005000dfedb832d1e17cab
     name: systemd-rpm-macros
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/unzip-6.0-57.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 186797
     checksum: sha256:29d78e253672a2e0717b2b290c3a0f831dcb54f89de79470c1af0d5fbaa41eff
     name: unzip
     evr: 6.0-57.el9
     sourcerpm: unzip-6.0-57.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-2.37.4-20.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 2391631
     checksum: sha256:a9c1d3f745da8e7d206ec1ec180e0fe484f114658b985636af5046867691cb71
     name: util-linux
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/u/util-linux-core-2.37.4-20.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 477330
     checksum: sha256:946a0d6adbd409f4040d726873fc451dac0c2c0b32cd3004498f548d5096a1fb
     name: util-linux-core
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/v/vim-filesystem-8.2.2637-21.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 17783
     checksum: sha256:a9fce2685b6dfe72b19ca93b274ff1ce709d14e6a8eb48eec5cd4a0d8205015b
     name: vim-filesystem
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/w/which-2.21-29.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 45104
     checksum: sha256:61eef3ee2dcd3d2e3b784464e801cbea2e8e668271b4aff97529110b45915191
     name: which
     evr: 2.21-29.el9
     sourcerpm: which-2.21-29.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/z/zip-3.0-35.el9.aarch64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-aarch64-baseos-rpms
     size: 269791
     checksum: sha256:4dfc9b2afc08b96cba0a8c7f06be5691ec26f2104d9c1a100aa0432e30aac3cd
     name: zip
@@ -2739,2730 +2739,2730 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/a/annobin-12.65-1.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1090130
     checksum: sha256:9cfe3427bef90b7c6b2cdfb3cb60182d8411fbc8f771c518d6aaffa3569d45eb
     name: annobin
     evr: 12.65-1.el9
     sourcerpm: annobin-12.65-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/b/brotli-1.0.9-7.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 320286
     checksum: sha256:9d9be6ff56dc68c384cb442ce07baf4f2ea21bdc95d81e182d45b3fe30bce2f1
     name: brotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/b/brotli-devel-1.0.9-7.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35192
     checksum: sha256:4d7eddea467c95912c33e091c8cf5648137f51e76707bf68b2bf51446718520d
     name: brotli-devel
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/b/bzip2-devel-1.0.8-10.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 220508
     checksum: sha256:fbc66785afdef1f892a96d545a4fc7be35b93578d1594b48212a6ae64e185562
     name: bzip2-devel
     evr: 1.0.8-10.el9_5
     sourcerpm: bzip2-1.0.8-10.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cairo-1.17.4-7.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 680200
     checksum: sha256:a97d3ff0ab1a6b028dd68e8753f13d568e7f3e66b6890531fd600bbc9817c4fc
     name: cairo
     evr: 1.17.4-7.el9
     sourcerpm: cairo-1.17.4-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cmake-filesystem-3.26.5-2.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 23450
     checksum: sha256:49fafe6c2b29fdede611a0a78664021d13f7126599e37ebff92bcb06d18f58b6
     name: cmake-filesystem
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11229073
     checksum: sha256:b5567c690d46d4f5a2cb13be6a4f962dbe8cc7e821b9d3baa09a4f10c59014d9
     name: cpp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/d/dwz-0.14-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 133177
     checksum: sha256:9b429a1abaadc0fd63cb0667ef5bc5ec4db4debc340f7f5742a9252dd8301a30
     name: dwz
     evr: 0.14-3.el9
     sourcerpm: dwz-0.14-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/e/efi-srpm-macros-6-2.el9_0.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24452
     checksum: sha256:1a1fa7561f5cef960b36c6a796d8a6fb4af70511118dacbfd5f707181a6c02fe
     name: efi-srpm-macros
     evr: 6-2.el9_0
     sourcerpm: efi-rpm-macros-6-2.el9_0.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fontconfig-2.14.0-2.el9_1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 307951
     checksum: sha256:229b88e1750e7b54de9049392350d202b1025f5750a7e4e55a575ffb9519a6ae
     name: fontconfig
     evr: 2.14.0-2.el9_1
     sourcerpm: fontconfig-2.14.0-2.el9_1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fontconfig-devel-2.14.0-2.el9_1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 182321
     checksum: sha256:ac97be8e947aa946073f66f14d1ad3be8c953897e9b82d2f4d7639637c03eaae
     name: fontconfig-devel
     evr: 2.14.0-2.el9_1
     sourcerpm: fontconfig-2.14.0-2.el9_1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/fonts-srpm-macros-2.0.5-7.el9.1.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 30140
     checksum: sha256:f8c6aaa6af574698f6d1a7eb8e7f6ed725e4366dc14553bc816f5aa305675367
     name: fonts-srpm-macros
     evr: 1:2.0.5-7.el9.1
     sourcerpm: fonts-rpm-macros-2.0.5-7.el9.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/f/freetype-devel-2.10.4-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1161949
     checksum: sha256:00efc4e7fdd54f4dfcedc32a31dbe4f5b1cae03a1e85797fcd4b99ec7d48a2e8
     name: freetype-devel
     evr: 2.10.4-9.el9
     sourcerpm: freetype-2.10.4-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 34006000
     checksum: sha256:03c99bc1021dbe54dd93120ed6b5249bbb02dbd5da9e0dc5d8c4a21d674fb1fd
     name: gcc
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-c++-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13479598
     checksum: sha256:b8392274e302d665bc132aee4ed023f8a777d9c446531679ede18150d7867189
     name: gcc-c++
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-plugin-annobin-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42533
     checksum: sha256:9af134e5b2e2fae5a0b33253abdad68c0cb854f14e2668853c9b42e00c098a5a
     name: gcc-plugin-annobin
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gd-2.3.2-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 137062
     checksum: sha256:abc95ba767b24940795af4b3a420825f24b8773e1f06cbb3b57d42bbc96acb86
     name: gd
     evr: 2.3.2-3.el9
     sourcerpm: gd-2.3.2-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gd-devel-2.3.2-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42359
     checksum: sha256:95c3dad42581989cef3ea3509acf21cb9c35c5ff7d521737d9d6fb58cf6114f3
     name: gd-devel
     evr: 2.3.2-3.el9
     sourcerpm: gd-2.3.2-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/ghc-srpm-macros-1.5.0-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9252
     checksum: sha256:80fb1c39b5d8c23352b8928332fa0794e679e054ffa3f04a34c2b18bb7e28c93
     name: ghc-srpm-macros
     evr: 1.5.0-6.el9
     sourcerpm: ghc-srpm-macros-1.5.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glib2-devel-2.68.4-14.el9_4.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 569462
     checksum: sha256:e5c1ac7c9134c01a8a4909b114ee3bd7726b7978f197416a8701ddb9a9d6d5a3
     name: glib2-devel
     evr: 2.68.4-14.el9_4.1
     sourcerpm: glib2-2.68.4-14.el9_4.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-125.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38332
     checksum: sha256:7ad500371d5034800ab8f5c6b4dd896801b1a97baa6a57bc6c982787afff2b20
     name: glibc-devel
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-125.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 556355
     checksum: sha256:16c84102b4457fc60ab9e46fd235bed4c9ac9dddf5cfeae3df51a5f00ce2dd5e
     name: glibc-headers
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/go-srpm-macros-3.6.0-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 29052
     checksum: sha256:831fb63c546286b319f9b2a9284ff8c1e34668172ac2d37dc722e7e8dca07120
     name: go-srpm-macros
     evr: 3.6.0-3.el9
     sourcerpm: go-rpm-macros-3.6.0-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gpm-libs-1.20.7-29.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 23036
     checksum: sha256:fc3455407e79462bfd944eea5d11d19186ad741be5a83e7ac1720fc181e3cc90
     name: gpm-libs
     evr: 1.20.7-29.el9
     sourcerpm: gpm-1.20.7-29.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/graphite2-devel-1.3.14-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24651
     checksum: sha256:c582065c2166a903aefa31d74faca878ed5220fed6fa1ec2cc15d8bcd267d2f4
     name: graphite2-devel
     evr: 1.3.14-9.el9
     sourcerpm: graphite2-1.3.14-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/h/harfbuzz-devel-2.7.4-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 359203
     checksum: sha256:23aa743ca73b972c98c4ef005f26414030cbc62c6a940a5b54ae47665870ae5c
     name: harfbuzz-devel
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/h/harfbuzz-icu-2.7.4-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14916
     checksum: sha256:a31ef6dbaf55c7b3d824dad300058aee3fa741c7679c50b313862580879b94e5
     name: harfbuzz-icu
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/j/jbigkit-libs-2.1-23.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 57187
     checksum: sha256:7da8bd49c92d873386b40567a7fa6b8604425bef2b5b1c5b8197bb999422dfb7
     name: jbigkit-libs
     evr: 2.1-23.el9
     sourcerpm: jbigkit-2.1-23.el9.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-503.26.1.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
-    size: 3929365
-    checksum: sha256:e3f6f637b01b759feb82ec8604552afb1c1d455381e06da7080bd666ebc45d68
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-503.29.1.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 3934489
+    checksum: sha256:9395568f2a4fe739578785b5edb70951dba83d957117a13b00dd951fa751b482
     name: kernel-headers
-    evr: 5.14.0-503.26.1.el9_5
-    sourcerpm: kernel-5.14.0-503.26.1.el9_5.src.rpm
+    evr: 5.14.0-503.29.1.el9_5
+    sourcerpm: kernel-5.14.0-503.29.1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-srpm-macros-1.0-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17792
     checksum: sha256:7e891fa264fb538bf4a26aa94e91ff0c3084bf2613e2061dbb6f4f0c26856777
     name: kernel-srpm-macros
     evr: 1.0-13.el9
     sourcerpm: kernel-srpm-macros-1.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libICE-1.0.10-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 75041
     checksum: sha256:55f9024a7f4b83b15aa56bce61ab3d4d9b9478930f33343c1f148774aa5e794e
     name: libICE
     evr: 1.0.10-8.el9
     sourcerpm: libICE-1.0.10-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libSM-1.2.3-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 45311
     checksum: sha256:032b0589e7033af71a0f10b7f95406a9956fbfc988a6aab3e7a3af5763e22f03
     name: libSM
     evr: 1.2.3-10.el9
     sourcerpm: libSM-1.2.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libX11-1.7.0-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 662789
     checksum: sha256:59a88a6889eec9188f1ef02f81655cd411f148ee67268fdf5abb4cebd2a9388c
     name: libX11
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libX11-common-1.7.0-9.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 214154
     checksum: sha256:cf55b0765528c4bf0176549f5835558c5883f3a918a71ca0d56a51e263f93d39
     name: libX11-common
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libX11-devel-1.7.0-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1151217
     checksum: sha256:44739f144c049b2a0ff827f15494f7f7c067b8785964140107f75c3c66c294bc
     name: libX11-devel
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libX11-xcb-1.7.0-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12524
     checksum: sha256:26ada7231f1250c515f91a0adec616217aea7d582d99349f23a16645033c8271
     name: libX11-xcb
     evr: 1.7.0-9.el9
     sourcerpm: libX11-1.7.0-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXau-1.0.9-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 34395
     checksum: sha256:ec895f13b3babb4ed27e5c5f6718c462808af58d636a90a45745accca8e26a94
     name: libXau
     evr: 1.0.9-8.el9
     sourcerpm: libXau-1.0.9-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXau-devel-1.0.9-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17492
     checksum: sha256:41bc270bacdadd040296057941337142483117504a5fc04aba8777de827933eb
     name: libXau-devel
     evr: 1.0.9-8.el9
     sourcerpm: libXau-1.0.9-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXext-1.3.4-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42529
     checksum: sha256:c295f071518f6366131e7b143e6c37f30caf6fdb51a0aec8ba516364e6bbde91
     name: libXext
     evr: 1.3.4-8.el9
     sourcerpm: libXext-1.3.4-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXpm-3.5.13-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 62114
     checksum: sha256:396c3c5ccf115683f9280b4907b3e1f43b8b830928717dd6de996de52a341ad2
     name: libXpm
     evr: 3.5.13-10.el9
     sourcerpm: libXpm-3.5.13-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXpm-devel-3.5.13-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38862
     checksum: sha256:f6aaaa55c9592573830b42b796e83fe6768bd65b8b0ed4781b9eb69b08f35e1e
     name: libXpm-devel
     evr: 3.5.13-10.el9
     sourcerpm: libXpm-3.5.13-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXrender-0.9.10-16.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 30453
     checksum: sha256:ab69ef172aaae7535eac07e516a4973d5d7e386e0e693af5f901806f7b527676
     name: libXrender
     evr: 0.9.10-16.el9
     sourcerpm: libXrender-0.9.10-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libXt-1.2.0-6.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 186234
     checksum: sha256:c362fe15befce1090a3c50c4b9d8b573383051ad0b1d99aa92975f6fdf74834a
     name: libXt
     evr: 1.2.0-6.el9
     sourcerpm: libXt-1.2.0-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libblkid-devel-2.37.4-20.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18780
     checksum: sha256:f0ce77e09486cad6d08e3326421aad976a55c378fb3ef32ccebe14e60caf4469
     name: libblkid-devel
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libdatrie-0.2.13-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35144
     checksum: sha256:21eb2f4481898f6de999b37c3dee2763ed6d530cf5a5147acad2da48871beae5
     name: libdatrie
     evr: 0.2.13-4.el9
     sourcerpm: libdatrie-0.2.13-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libffi-devel-3.4.2-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 32520
     checksum: sha256:cd74ba2a4bac6b9f7df20e50915e0aeee6581dd815d3a388eb3f9c45565cef68
     name: libffi-devel
     evr: 3.4.2-8.el9
     sourcerpm: libffi-3.4.2-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libgpg-error-devel-1.42-5.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 70899
     checksum: sha256:3bbaa1add2e083a43ce0cb9e1c1a35ad8a5e8f2f56280b8f1ab241194acc56d6
     name: libgpg-error-devel
     evr: 1.42-5.el9
     sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libicu-devel-67.1-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 965138
     checksum: sha256:d642757e141bc703a21848439ef997411c522e498f3cd7b2678e5eb0b2d5553b
     name: libicu-devel
     evr: 67.1-9.el9
     sourcerpm: icu-67.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libjpeg-turbo-2.0.90-7.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 181774
     checksum: sha256:281d740f3732d785382e56fdd61a62c2608bcce740c3dc34b57ec55136cf7201
     name: libjpeg-turbo
     evr: 2.0.90-7.el9
     sourcerpm: libjpeg-turbo-2.0.90-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libjpeg-turbo-devel-2.0.90-7.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 105265
     checksum: sha256:29bc1734fd78b4d11c71adbf37fb11c2fbe7920884c0dd475d9b0a6bc05bc6ba
     name: libjpeg-turbo-devel
     evr: 2.0.90-7.el9
     sourcerpm: libjpeg-turbo-2.0.90-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmount-devel-2.37.4-20.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 19471
     checksum: sha256:3e0931b770094ad9cdf38f136b43fa61dec2ffd1cd44a50bf6785de321cbafa7
     name: libmount-devel
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 66075
     checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libpng-devel-1.6.37-12.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 304447
     checksum: sha256:842e081a7ae18f6b87451388199ce82836d92ec1cfcb81f0a3832b44baf5f4af
     name: libpng-devel
     evr: 2:1.6.37-12.el9
     sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libselinux-devel-3.6-1.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 167247
     checksum: sha256:44b774df2bbb010b4c0fffdfbe73061af0d4a4d6386f04027deab349c02f9ad3
     name: libselinux-devel
     evr: 3.6-1.el9
     sourcerpm: libselinux-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libsepol-devel-3.6-1.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52617
     checksum: sha256:3c9725a32552afb8244f619a94ff1c9eda80b883d1311b29df734ac18a7432fb
     name: libsepol-devel
     evr: 3.6-1.el9
     sourcerpm: libsepol-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libstdc++-devel-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 2531717
     checksum: sha256:84695eeeb1daa8ff74baf7efd9fc57fb136bec7e8a2ca56c105be6d83ec22d07
     name: libstdc++-devel
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libthai-0.1.28-8.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 216254
     checksum: sha256:289d4e53a6d59ba84dffc9ad5f8312bf9c14dc7528556e1a0e94c71428ead7e1
     name: libthai
     evr: 0.1.28-8.el9
     sourcerpm: libthai-0.1.28-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtiff-4.4.0-13.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 205730
     checksum: sha256:6ee26a0195f923cfb6b80aa2b87212218c3c906625bf850ad0780752ee16c170
     name: libtiff
     evr: 4.4.0-13.el9
     sourcerpm: libtiff-4.4.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libtiff-devel-4.4.0-13.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 573178
     checksum: sha256:8550417639a9665ec85b81da800be12fd5b7ff7db9595327bed28f5726ff18e3
     name: libtiff-devel
     evr: 4.4.0-13.el9
     sourcerpm: libtiff-4.4.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libwebp-1.2.0-8.el9_3.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 289212
     checksum: sha256:6b99032107aa1d6b28dd98c44b0dc6451ce632627ccf6da0c29ac34fd5f501e8
     name: libwebp
     evr: 1.2.0-8.el9_3
     sourcerpm: libwebp-1.2.0-8.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libwebp-devel-1.2.0-8.el9_3.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 36924
     checksum: sha256:227d7a6e63cd3ebde97981ba9ea5adbf88e75c87579881fd5d084c8409bb7ad7
     name: libwebp-devel
     evr: 1.2.0-8.el9_3
     sourcerpm: libwebp-1.2.0-8.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcb-1.13.1-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 252989
     checksum: sha256:a95c41c93768b9f4a1a0a57140866f5e48dc722d15ae10b39edab8b24794e5bf
     name: libxcb
     evr: 1.13.1-9.el9
     sourcerpm: libxcb-1.13.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcb-devel-1.13.1-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1617351
     checksum: sha256:100f7d1f498e570670a6bc4e08e33ab398c8535d3bc3693a9b486f9964a66325
     name: libxcb-devel
     evr: 1.13.1-9.el9
     sourcerpm: libxcb-1.13.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 93189
     checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
     name: libxcrypt-compat
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 33101
     checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
     name: libxcrypt-devel
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxml2-devel-2.9.13-6.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 923699
     checksum: sha256:1c390d9f119998a8f2d07a462338f35226ebb3d8f2d4c1fbaae959667af7f13e
     name: libxml2-devel
     evr: 2.9.13-6.el9_5.1
     sourcerpm: libxml2-2.9.13-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxslt-1.1.34-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 252634
     checksum: sha256:48efd7c1c0061eea12b162a9645519ab70bd31a6bf5ef9135396f77aa34c4707
     name: libxslt
     evr: 1.1.34-9.el9
     sourcerpm: libxslt-1.1.34-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxslt-devel-1.1.34-9.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 331619
     checksum: sha256:fa3f4d7fd5a540766f3faa8e5f8c6a42cbcedc8dca9a100eaa84bcb3586d39de
     name: libxslt-devel
     evr: 1.1.34-9.el9
     sourcerpm: libxslt-1.1.34-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-18.1.8-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 27114350
     checksum: sha256:9ea68fe509d5adf70fc797d689046fae6ddc073f91940a4198ff25aeb489ad04
     name: llvm-libs
     evr: 18.1.8-3.el9
     sourcerpm: llvm-18.1.8-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/lua-srpm-macros-1-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 10476
     checksum: sha256:64946edfd54f7d4668f7fdcb7be961ceaca8cff7d0bef438bef4e2498ccf3cd6
     name: lua-srpm-macros
     evr: 1-6.el9
     sourcerpm: lua-rpm-macros-1-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/ocaml-srpm-macros-6-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9270
     checksum: sha256:783710ad3710e594275fb23d280f030a68279927ca82ce38787f4c93971eaa88
     name: ocaml-srpm-macros
     evr: 6-6.el9
     sourcerpm: ocaml-srpm-macros-6-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openblas-srpm-macros-2-11.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 8807
     checksum: sha256:091911db0712bfe9b03952046191438bdd9b1080558e0c1014611d39aa80571d
     name: openblas-srpm-macros
     evr: 2-11.el9
     sourcerpm: openblas-srpm-macros-2-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/openssl-devel-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 4650823
     checksum: sha256:30cd1b3dec089a7da71e9167532693bef7c202a5dbe3c010af2a9387106a0b36
     name: openssl-devel
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-cpp-8.44-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 27327
     checksum: sha256:8d627da32ee74ce4855162c6b592d1693084645d078ca3c229af138dd9da5f2a
     name: pcre-cpp
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-devel-8.44-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 522466
     checksum: sha256:9e164aa48810dbdf2d8373dfaccdccf7a51c78c75a2c459074d41e661aa6a665
     name: pcre-devel
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-utf16-8.44-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 190856
     checksum: sha256:bab46d49557b6f8a20e1c367e22bf9c7a6b802e97e6acb506ccb1fd5c06debe3
     name: pcre-utf16
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre-utf32-8.44-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 181048
     checksum: sha256:1c9aad468e260629903304f29bac36faddb3960e67dc543502c4ec7900d84f01
     name: pcre-utf32
     evr: 8.44-4.el9
     sourcerpm: pcre-8.44-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre2-devel-10.40-6.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 528624
     checksum: sha256:f2fa0c49019f12b9c01986c1d05ffc83863ac7b47b8e348d6357e7fbdf3b17e3
     name: pcre2-devel
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre2-utf16-10.40-6.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 220256
     checksum: sha256:935664188bce50473e3c148fc9d71167d3881fc2de9ccc99394c03d00e8ff5b3
     name: pcre2-utf16
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pcre2-utf32-10.40-6.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 209174
     checksum: sha256:d50fc56a1e9710b3374826c82044d4624b6c5949db0178d5774f575a5fcd6934
     name: pcre2-utf32
     evr: 10.40-6.el9
     sourcerpm: pcre2-10.40-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-5.32.1-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12557
     checksum: sha256:1c5f769a69ef07a81af53d662894591c35b979c33ab8144f09302146b922ee03
     name: perl
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Algorithm-Diff-1.2010-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52041
     checksum: sha256:3d252e247a41978a10faef66931ac5fb2525c7fa708d8caa537d368ef5ba62ce
     name: perl-Algorithm-Diff
     evr: 1.2010-4.el9
     sourcerpm: perl-Algorithm-Diff-1.2010-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Archive-Tar-2.38-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 77744
     checksum: sha256:5cf97230d350543cdf34f379dc04e1383f89591ad76768b5a2738b474cdec404
     name: perl-Archive-Tar
     evr: 2.38-6.el9
     sourcerpm: perl-Archive-Tar-2.38-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Archive-Zip-1.68-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 118766
     checksum: sha256:2237a7cdfa30cda2ad475cb6ee5796f1e4cafa07e8760e08bca8d252cd6eb51d
     name: perl-Archive-Zip
     evr: 1.68-6.el9
     sourcerpm: perl-Archive-Zip-1.68-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Attribute-Handlers-1.01-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 28435
     checksum: sha256:03d4f6339d78bf32658aa68b713e15a01ff544e88a7565e8ee595e053b6ec8ea
     name: perl-Attribute-Handlers
     evr: 1.01-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-AutoLoader-5.74-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21821
     checksum: sha256:52cda881960f48be35a47ba1c54f242efac1ab0d1fd74b0e2bcb48a1723907c8
     name: perl-AutoLoader
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-AutoSplit-5.74-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22186
     checksum: sha256:d962ffc07516d9f0ed0d9a5c21e16677598afa8f10a40c6555ae9a35e6a2d43b
     name: perl-AutoSplit
     evr: 5.74-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-B-1.80-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 188182
     checksum: sha256:1d9743f0a5ba875908984dbe875025aa51bc62fc9d1bec3fbef12f6688c1d771
     name: perl-B
     evr: 1.80-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Benchmark-1.23-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 27531
     checksum: sha256:b19c10012210bfdd3566986e4222cd94183e56e496d3e2ddf03743c45689818b
     name: perl-Benchmark
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-CPAN-2.29-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 588870
     checksum: sha256:b38e3427041166797b36980580c2144835342cefeacd6effca184ac3e526bc84
     name: perl-CPAN
     evr: 2.29-3.el9
     sourcerpm: perl-CPAN-2.29-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-CPAN-DistnameInfo-0.12-23.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17060
     checksum: sha256:35687783ded44b01c37af59f66499b42e10df074c36608fc3f84bd4ae082c852
     name: perl-CPAN-DistnameInfo
     evr: 0.12-23.el9
     sourcerpm: perl-CPAN-DistnameInfo-0.12-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-CPAN-Meta-2.150010-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 210745
     checksum: sha256:ec35026baabe720d7c880f896f84271f0c408c56d3fea6d7c5d22580ac175690
     name: perl-CPAN-Meta
     evr: 2.150010-460.el9
     sourcerpm: perl-CPAN-Meta-2.150010-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-CPAN-Meta-Requirements-2.140-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35205
     checksum: sha256:eca17976f76fd8d31eda995a9ced2d813c1c94b9efafa1a83454fb120be62784
     name: perl-CPAN-Meta-Requirements
     evr: 2.140-461.el9
     sourcerpm: perl-CPAN-Meta-Requirements-2.140-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-CPAN-Meta-YAML-0.018-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 29542
     checksum: sha256:b21eb298e56bc6623257cae1434198789e80ab92b818af4e29514a7bbc6f5910
     name: perl-CPAN-Meta-YAML
     evr: 0.018-461.el9
     sourcerpm: perl-CPAN-Meta-YAML-0.018-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Carp-1.50-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 32039
     checksum: sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2
     name: perl-Carp
     evr: 1.50-460.el9
     sourcerpm: perl-Carp-1.50-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Class-Struct-0.66-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22914
     checksum: sha256:45347749c36c4750c9083d4784700fb85c3a4c277c3bf69873a1c6ae97ee6c4b
     name: perl-Class-Struct
     evr: 0.66-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Compress-Bzip2-2.28-5.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 75359
     checksum: sha256:ec290efc1b75d09f29bde0a52758ec46b959f8273a89f8118e062da98862c9d3
     name: perl-Compress-Bzip2
     evr: 2.28-5.el9
     sourcerpm: perl-Compress-Bzip2-2.28-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Compress-Raw-Bzip2-2.101-5.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 39060
     checksum: sha256:bcaa6bb1dc582507d04551f9aac3f7a049f26e48476b1b08184f2647466adde5
     name: perl-Compress-Raw-Bzip2
     evr: 2.101-5.el9
     sourcerpm: perl-Compress-Raw-Bzip2-2.101-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Compress-Raw-Lzma-2.101-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 55819
     checksum: sha256:da1dd21f15039f8c3c6e79f40b201a73d28fc11825c771dd51cc4a14972d4b23
     name: perl-Compress-Raw-Lzma
     evr: 2.101-3.el9
     sourcerpm: perl-Compress-Raw-Lzma-2.101-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Compress-Raw-Zlib-2.101-5.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 65949
     checksum: sha256:c638818fb0baf3c36166b1d0a674fa63d58aeacaa9edd91b2519278b112f33b7
     name: perl-Compress-Raw-Zlib
     evr: 2.101-5.el9
     sourcerpm: perl-Compress-Raw-Zlib-2.101-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Config-Extensions-0.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12815
     checksum: sha256:840607ca387a3076f9ee0f40060f6a2b559779ec2a4647e073a5e24fc713e36f
     name: perl-Config-Extensions
     evr: 0.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Config-Perl-V-0.33-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24943
     checksum: sha256:7ec321ecb6f37b6be09ad182cb66fdeee9f12138f75fc48858bde2177c358d1d
     name: perl-Config-Perl-V
     evr: 0.33-4.el9
     sourcerpm: perl-Config-Perl-V-0.33-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-DBM_Filter-0.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35000
     checksum: sha256:b5dbe5adabdd6602224ee8178743b4f34b80d585ab838cb3ad1f2cae99b0e9dc
     name: perl-DBM_Filter
     evr: 0.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-DB_File-1.855-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 86215
     checksum: sha256:8c99c19d93e32729c6eefa704e4a3f9dc08b2c693c525cc3717661aefccd18c8
     name: perl-DB_File
     evr: 1.855-4.el9
     sourcerpm: perl-DB_File-1.855-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Data-Dumper-2.174-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 59910
     checksum: sha256:6cd912e640cbc8785e33dae9cf07561509491a0ec76a81c01d6b7a77ad08668d
     name: perl-Data-Dumper
     evr: 2.174-462.el9
     sourcerpm: perl-Data-Dumper-2.174-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Data-OptList-0.110-17.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 30694
     checksum: sha256:1455a3e90116f504008f8d27db57acb65c3389440dc6e2d605f54bf40b009a10
     name: perl-Data-OptList
     evr: 0.110-17.el9
     sourcerpm: perl-Data-OptList-0.110-17.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Data-Section-0.200007-14.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 28030
     checksum: sha256:9fb57b4fbcfea93de114505082261abd97f576cf78e1a205c255d69d8eb6babf
     name: perl-Data-Section
     evr: 0.200007-14.el9
     sourcerpm: perl-Data-Section-0.200007-14.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Devel-PPPort-3.62-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 220678
     checksum: sha256:5edf31d2993a73056802f4281108e4636f33e5c7d5cb910cdb45996475baee73
     name: perl-Devel-PPPort
     evr: 3.62-4.el9
     sourcerpm: perl-Devel-PPPort-3.62-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Devel-Peek-1.28-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 34594
     checksum: sha256:a135b356a365fb466f72e04f172d0aae507ca32508afffb1ae565b00f0e34968
     name: perl-Devel-Peek
     evr: 1.28-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Devel-SelfStubber-1.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14932
     checksum: sha256:5b39f719f3e1da497d92b87d597269686925bf08006f8e2c1c92ec0bb8cd9482
     name: perl-Devel-SelfStubber
     evr: 1.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Devel-Size-0.83-10.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35096
     checksum: sha256:84738fe6f546dae38e113c340c66f3b8adbd466328f22dc15ec481b793cdf922
     name: perl-Devel-Size
     evr: 0.83-10.el9
     sourcerpm: perl-Devel-Size-0.83-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Digest-1.19-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 29409
     checksum: sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9
     name: perl-Digest
     evr: 1.19-4.el9
     sourcerpm: perl-Digest-1.19-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.58-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 40274
     checksum: sha256:2a6b21a144ae1d060e51ee2b6328c5dd1a646f429da160f386c2eb420b1220b4
     name: perl-Digest-MD5
     evr: 2.58-4.el9
     sourcerpm: perl-Digest-MD5-2.58-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Digest-SHA-6.02-461.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 67580
     checksum: sha256:251519573b1785a2102bb235c3a3fea5f6d7b949176969eb0a0fcd69883df4a5
     name: perl-Digest-SHA
     evr: 1:6.02-461.el9
     sourcerpm: perl-Digest-SHA-6.02-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Digest-SHA1-2.13-34.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 57553
     checksum: sha256:0f8d777e8c8cab429c3963c477ae16fa7233c568b88e309ee89478ce81b7b3d6
     name: perl-Digest-SHA1
     evr: 2.13-34.el9
     sourcerpm: perl-Digest-SHA1-2.13-34.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-DirHandle-1.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12799
     checksum: sha256:b50fdd94649f82218308bd6d0ba5d6e20f658d6fc448aaa1327398443dfaefc7
     name: perl-DirHandle
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Dumpvalue-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18822
     checksum: sha256:60e541f90705e444171f50078c0f1137fcff5576124cbb729768a99386e2016d
     name: perl-Dumpvalue
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-DynaLoader-1.47-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 26423
     checksum: sha256:f238e85f5fe854109793f966e7e36f14165979aee78fc2de39037b9f69ca3178
     name: perl-DynaLoader
     evr: 1.47-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Encode-3.08-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1802386
     checksum: sha256:d05248697e48928be004ed4c683b04966aa452ae1e2bd81f650c6de108b46956
     name: perl-Encode
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Encode-Locale-1.05-21.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21500
     checksum: sha256:58afacf30f4a476f4ba6646a6419122d2a729bd59880611b631527502dcdc269
     name: perl-Encode-Locale
     evr: 1.05-21.el9
     sourcerpm: perl-Encode-Locale-1.05-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Encode-devel-3.08-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 45176
     checksum: sha256:8c5dc8e93efddb8ad14fd0a98b1d076cf0b6912b4542a4d4ec6a136f0f1ea797
     name: perl-Encode-devel
     evr: 4:3.08-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-English-1.11-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13988
     checksum: sha256:51234583bb690fe57ac54a9efca0e4ab51e75f1ad6133e9e1b579b9f851b6575
     name: perl-English
     evr: 1.11-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Env-1.04-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22160
     checksum: sha256:92fb2287084a3c88a6b2d2bd300d1279251cec59156c1a9a3e0fa8fda6c546b2
     name: perl-Env
     evr: 1.04-460.el9
     sourcerpm: perl-Env-1.04-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Errno-1.30-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15331
     checksum: sha256:891006d2a5ec8528b1e7fe181a3e1617733b1050250b381f29261b70e83865ed
     name: perl-Errno
     evr: 1.30-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Exporter-5.74-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 34509
     checksum: sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409
     name: perl-Exporter
     evr: 5.74-461.el9
     sourcerpm: perl-Exporter-5.74-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-CBuilder-0.280236-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 54624
     checksum: sha256:1f03cdbebc6f7b1b877e170363ab4906d194aa5edbaee17df724ca7ffc972011
     name: perl-ExtUtils-CBuilder
     evr: 1:0.280236-4.el9
     sourcerpm: perl-ExtUtils-CBuilder-0.280236-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Command-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16489
     checksum: sha256:642338ff95d94e2c6e4b7de47cda7b772d1fbc204b2869925bd0326fcc4b0e26
     name: perl-ExtUtils-Command
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Constant-0.25-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 49788
     checksum: sha256:49aa4d69ad3bfbc05da33c2c88eb82815c76c7b605831012fbed054d9fe2ceb5
     name: perl-ExtUtils-Constant
     evr: 0.25-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Embed-1.35-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18371
     checksum: sha256:cfa0a13f9d7f2b99c40d17f77b03460ef765c5e046c69d46efe057e42d988f33
     name: perl-ExtUtils-Embed
     evr: 1.35-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Install-2.20-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48441
     checksum: sha256:2533a1d97d45dc79c07cc51409c34f188c042757a2811b04dc16892ae2c7443e
     name: perl-ExtUtils-Install
     evr: 2.20-4.el9
     sourcerpm: perl-ExtUtils-Install-2.20-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-MM-Utils-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14176
     checksum: sha256:51d7199c10886580e6cbff82546a34f26b2d5b894dcc338e28b1b55938f50ae3
     name: perl-ExtUtils-MM-Utils
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-MakeMaker-7.60-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 311769
     checksum: sha256:2286e5004cb6436b7ac8dd436c91b4e1d36c18b9385d07a24fc167c930c9dee8
     name: perl-ExtUtils-MakeMaker
     evr: 2:7.60-3.el9
     sourcerpm: perl-ExtUtils-MakeMaker-7.60-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Manifest-1.73-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 37829
     checksum: sha256:f7cf7fd259fb8a6c27537dc98e1ed4923b26c2d8d8fd6b789e166ac104cac5bc
     name: perl-ExtUtils-Manifest
     evr: 1:1.73-4.el9
     sourcerpm: perl-ExtUtils-Manifest-1.73-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-Miniperl-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15866
     checksum: sha256:15a90a1f4c0b11048633e996d9887b83db8a48031e1ba2560e72573c328c4cf5
     name: perl-ExtUtils-Miniperl
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ExtUtils-ParseXS-3.40-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 194711
     checksum: sha256:bb7e4bcfe24371bbe202a9fa704360a7bbc5d9f4103ec36e6e571da6eb76a186
     name: perl-ExtUtils-ParseXS
     evr: 1:3.40-460.el9
     sourcerpm: perl-ExtUtils-ParseXS-3.40-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Fcntl-1.13-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22098
     checksum: sha256:726645728dabb2f1badb1c4a6170c5db29118a536cdfa482c882aaef6ed97fb4
     name: perl-Fcntl
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Basename-2.85-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17916
     checksum: sha256:746f919f1aebc91a28f00e20eda7b41991db9e50abf2fa22cd7f8168a8f9898a
     name: perl-File-Basename
     evr: 2.85-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Compare-1.100.600-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13854
     checksum: sha256:2108ae5f9e3edf870a30a717b6cf999be70b36e50b715b02d5256cdf07f91764
     name: perl-File-Compare
     evr: 1.100.600-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Copy-2.34-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 20838
     checksum: sha256:d547160cfc5e02e3381116185cc5c125c680c2fab6ab7e6696fd95b8e4fdbb4a
     name: perl-File-Copy
     evr: 2.34-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-DosGlob-1.12-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21769
     checksum: sha256:28b3031b8b1d406e5e19d15ed59d0a1933d05e71ab397889d93c46f1c0e9e450
     name: perl-File-DosGlob
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Fetch-1.00-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 33372
     checksum: sha256:8c46735b0f703cd53fbaf915423b63baf98701d81406b30b84e42e53a0efbb6e
     name: perl-File-Fetch
     evr: 1.00-4.el9
     sourcerpm: perl-File-Fetch-1.00-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Find-1.37-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 26277
     checksum: sha256:e388937b023c024de285a5b50fe3f44722c18207d7d854aff302f4ad3c8742f4
     name: perl-File-Find
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-HomeDir-1.006-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 65857
     checksum: sha256:68f539b86abb7ab910286188ad3742f4338330f3246f6da07cb4ca5c83d8e80f
     name: perl-File-HomeDir
     evr: 1.006-4.el9
     sourcerpm: perl-File-HomeDir-1.006-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Path-2.18-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38466
     checksum: sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41
     name: perl-File-Path
     evr: 2.18-4.el9
     sourcerpm: perl-File-Path-2.18-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Temp-0.231.100-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 64150
     checksum: sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03
     name: perl-File-Temp
     evr: 1:0.231.100-4.el9
     sourcerpm: perl-File-Temp-0.231.100-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-Which-1.23-10.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24163
     checksum: sha256:80a41f9f823312dca2c9fed97f6568a88957572277b75920fb76f20a60902e7f
     name: perl-File-Which
     evr: 1.23-10.el9
     sourcerpm: perl-File-Which-1.23-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-File-stat-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17853
     checksum: sha256:355aba30d043f829e4e7e70466564ba85f65f7a2416aba0ceddfc9e59288aab4
     name: perl-File-stat
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-FileCache-1.10-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15108
     checksum: sha256:1da22e9c110f143c1dfbd827fefcac6ad514d6bedddb6d3d4152206e0abfc886
     name: perl-FileCache
     evr: 1.10-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-FileHandle-2.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15921
     checksum: sha256:480ac4c1de2c1e1f94ed8895793b93d96bd50dc95e6e4fa9c39a82a24998f717
     name: perl-FileHandle
     evr: 2.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Filter-1.60-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 97662
     checksum: sha256:f4fca2ffe54fa291963cfdb816ed4830f75b5be5f70964a73820e4736b242792
     name: perl-Filter
     evr: 2:1.60-4.el9
     sourcerpm: perl-Filter-1.60-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Filter-Simple-0.96-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 29899
     checksum: sha256:080a1c4c16acddca179c0e2ab8120fe01e374bb86d0a950923a610e50fabfc00
     name: perl-Filter-Simple
     evr: 0.96-460.el9
     sourcerpm: perl-Filter-Simple-0.96-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-FindBin-1.51-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14336
     checksum: sha256:43ef0a61ba09f0213bf7eaf3af905d98b4879fa3e383f1340cad23de1ae46f67
     name: perl-FindBin
     evr: 1.51-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-GDBM_File-1.18-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24179
     checksum: sha256:ceaf8f3ae86e8fbf66b792512000219dd1bcac1df3992a72aa6c85e934388958
     name: perl-GDBM_File
     evr: 1.18-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Long-2.52-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 65144
     checksum: sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14
     name: perl-Getopt-Long
     evr: 1:2.52-4.el9
     sourcerpm: perl-Getopt-Long-2.52-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Getopt-Std-1.12-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16222
     checksum: sha256:c9c6209474ec44ca5b070ffb147589359c551757f95b358a8f35d2627c4950cf
     name: perl-Getopt-Std
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-HTTP-Tiny-0.076-462.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 58720
     checksum: sha256:696f388a50f5be81596757d68251067449203e1c126ee8c23a7c5a0ad1ac5418
     name: perl-HTTP-Tiny
     evr: 0.076-462.el9
     sourcerpm: perl-HTTP-Tiny-0.076-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Hash-Util-0.23-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 36417
     checksum: sha256:cab1ae23cc23573b1d6408c1e0ff06132639bcaf523dd53737ae3e534015c6a7
     name: perl-Hash-Util
     evr: 0.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Hash-Util-FieldHash-1.20-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 40953
     checksum: sha256:b00cc5b1a6f8d3dba8ce93c582d596f4674fc6a30c640478c3896d10bafe7aea
     name: perl-Hash-Util-FieldHash
     evr: 1.20-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-I18N-Collate-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14785
     checksum: sha256:440007c7d78ddc63839ff9bfe8b82acbd939452f3ada8a1b34288aabd2865150
     name: perl-I18N-Collate
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-I18N-LangTags-0.44-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 57020
     checksum: sha256:5812d857fdf616511fc9f4b7ed463f9e3126d85166d56bdd7c7a64d8c2db41bb
     name: perl-I18N-LangTags
     evr: 0.44-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-I18N-Langinfo-0.19-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24714
     checksum: sha256:c528e99a34a1be0cd64de1ba8ccf0d3960e69b1f9ff9fce88116f34cdb64ad1f
     name: perl-I18N-Langinfo
     evr: 0.19-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-1.43-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 94663
     checksum: sha256:dc85c28902667c1bd3c6f19b6a08bdda5e1d25b11e832b269e15fde94e6ab52d
     name: perl-IO
     evr: 1.43-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-Compress-2.102-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 280708
     checksum: sha256:ce8f2004395442fe663cb9efc56f9af2102c75d746f2ce393e40af8a26ac6871
     name: perl-IO-Compress
     evr: 2.102-4.el9
     sourcerpm: perl-IO-Compress-2.102-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-Compress-Lzma-2.101-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 84153
     checksum: sha256:bda4c005c09e886ce2273a3f418f0cd92521ed0b8fdcdaca7b9fc0026f2a6c7b
     name: perl-IO-Compress-Lzma
     evr: 2.101-4.el9
     sourcerpm: perl-IO-Compress-Lzma-2.101-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 46457
     checksum: sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f
     name: perl-IO-Socket-IP
     evr: 0.41-5.el9
     sourcerpm: perl-IO-Socket-IP-0.41-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.073-2.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 226003
     checksum: sha256:b52d5b6a5081e3c142b2364b3f1ef58f569b39052df045f24363de9bb4f9cfd2
     name: perl-IO-Socket-SSL
     evr: 2.073-2.el9
     sourcerpm: perl-IO-Socket-SSL-2.073-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IO-Zlib-1.11-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21809
     checksum: sha256:87d7b757a570fb53d72b2dd29558c2b4a8ff33196a80ad10f76999325acaec07
     name: perl-IO-Zlib
     evr: 1:1.11-4.el9
     sourcerpm: perl-IO-Zlib-1.11-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IPC-Cmd-1.04-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42803
     checksum: sha256:353b04bed7229ce354a4d63ba213c4e18fe739c4732061957946b84853d5b3ce
     name: perl-IPC-Cmd
     evr: 2:1.04-461.el9
     sourcerpm: perl-IPC-Cmd-1.04-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IPC-Open3-1.21-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24124
     checksum: sha256:422c83bcdd2f84d9751fe4ea289e6bc8bfbc41e6540d6482671317fbc2ff1a17
     name: perl-IPC-Open3
     evr: 1.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IPC-SysV-2.09-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48576
     checksum: sha256:134cb54df211888941ee8666bd96b9026c73202f4e56e6f664319627d2dbfee3
     name: perl-IPC-SysV
     evr: 2.09-4.el9
     sourcerpm: perl-IPC-SysV-2.09-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-IPC-System-Simple-1.30-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 44255
     checksum: sha256:35792b1aa241cb17b881b1e44940bc295329a575a2a2d183757ef1d757062465
     name: perl-IPC-System-Simple
     evr: 1.30-6.el9
     sourcerpm: perl-IPC-System-Simple-1.30-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Importer-0.026-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42526
     checksum: sha256:1afb9008ad841ba4fc207af8ec814d06bd78e958cd2b03089c7b82c71a311060
     name: perl-Importer
     evr: 0.026-4.el9
     sourcerpm: perl-Importer-0.026-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-JSON-PP-4.06-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 70596
     checksum: sha256:17f547d40976904eb59449f0cdec890e34632a28a083fc46157ac1c67e9e3494
     name: perl-JSON-PP
     evr: 1:4.06-4.el9
     sourcerpm: perl-JSON-PP-4.06-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Locale-Maketext-1.29-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 101003
     checksum: sha256:97cfef112a414049f85495cbec570b8c63d7260410f72cb2e1480a67fc7e9e68
     name: perl-Locale-Maketext
     evr: 1.29-461.el9
     sourcerpm: perl-Locale-Maketext-1.29-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Locale-Maketext-Simple-0.21-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18568
     checksum: sha256:20fd5bd35208c94b669179c7e6a295a6fe6abee69e0ce284e0ab25562bcff9c3
     name: perl-Locale-Maketext-Simple
     evr: 1:0.21-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-MIME-Base64-3.16-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35058
     checksum: sha256:3ae8affe13cc15cfaee1c6dd078ada14891dde5dca263927a9b5ed87f241d2c0
     name: perl-MIME-Base64
     evr: 3.16-4.el9
     sourcerpm: perl-MIME-Base64-3.16-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-MIME-Charset-1.012.2-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 54488
     checksum: sha256:cf481c2178bc2a55c5b455749f38f4f96ee71f32dcf458c34d4f1bbcb996feca
     name: perl-MIME-Charset
     evr: 1.012.2-15.el9
     sourcerpm: perl-MIME-Charset-1.012.2-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-MRO-Compat-0.13-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22804
     checksum: sha256:7921d8fd6d4dacdfb4a286fe4355516f20d660681abb49af9983f7527429e351
     name: perl-MRO-Compat
     evr: 0.13-15.el9
     sourcerpm: perl-MRO-Compat-0.13-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Math-BigInt-1.9998.18-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 198900
     checksum: sha256:b90555cc3da95e314e931de2348d7c89da7c16023fb9399cdfbbcf9f1aeade7d
     name: perl-Math-BigInt
     evr: 1:1.9998.18-460.el9
     sourcerpm: perl-Math-BigInt-1.9998.18-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Math-BigInt-FastCalc-0.500.900-460.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 32582
     checksum: sha256:d09dc3590797f1d5a94baa1f24883e2a2f19b80cfa3276f3f8cec41d4ccd4d93
     name: perl-Math-BigInt-FastCalc
     evr: 0.500.900-460.el9
     sourcerpm: perl-Math-BigInt-FastCalc-0.500.900-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Math-BigRat-0.2614-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 42414
     checksum: sha256:c31888896769451095c352ea97a1c88e2bbbc27d5bdc1e018dc8bae680967fb0
     name: perl-Math-BigRat
     evr: 0.2614-460.el9
     sourcerpm: perl-Math-BigRat-0.2614-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Math-Complex-1.59-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48567
     checksum: sha256:f53531125d6df72f4b50be888b7c3352a4032a5207a7bad774a2658b46d4edad
     name: perl-Math-Complex
     evr: 1.59-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Memoize-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 61549
     checksum: sha256:8ca298bbaff33a951e338d0213560610bd06cf5a3783bb83c34318e9d91b5a72
     name: perl-Memoize
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Build-0.42.31-9.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 274094
     checksum: sha256:9e33e1a46048d262ebe06f98c6c7b1579cdf92db57b0bb4228d13883c232d82c
     name: perl-Module-Build
     evr: 2:0.42.31-9.el9
     sourcerpm: perl-Module-Build-0.42.31-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-CoreList-5.20210320-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 86597
     checksum: sha256:f495039e4a0f025576e5469adc82d12419d8e843325f801cd6bfe80315c239f1
     name: perl-Module-CoreList
     evr: 1:5.20210320-3.el9
     sourcerpm: perl-Module-CoreList-5.20210320-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-CoreList-tools-5.20210320-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 20685
     checksum: sha256:7307f9abaec98de60cd8d1d1fc2820485323d7152c256356735890b0755f6e4e
     name: perl-Module-CoreList-tools
     evr: 1:5.20210320-3.el9
     sourcerpm: perl-Module-CoreList-5.20210320-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Load-0.36-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 20052
     checksum: sha256:ada066ac44fd73ec87ea376a6d6715cf77b086354217fdc7a197c909da3bb099
     name: perl-Module-Load
     evr: 1:0.36-4.el9
     sourcerpm: perl-Module-Load-0.36-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Load-Conditional-0.74-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25464
     checksum: sha256:58a5364d77607678e4e628f5bdd3d33641e2f6083c2985c1bc5045401ae65a60
     name: perl-Module-Load-Conditional
     evr: 0.74-4.el9
     sourcerpm: perl-Module-Load-Conditional-0.74-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Loaded-0.08-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13935
     checksum: sha256:6651d40ae9a673262240d750f1b4236eb8db8f9a4a81ff3d529be1e65ea0a098
     name: perl-Module-Loaded
     evr: 1:0.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Metadata-1.000037-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 39221
     checksum: sha256:f053b34c911e5f3daf16c0ffc5ff752f47a0d016e1cc1ac51d4425fbe2a1ac15
     name: perl-Module-Metadata
     evr: 1.000037-460.el9
     sourcerpm: perl-Module-Metadata-1.000037-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Module-Signature-0.88-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 89282
     checksum: sha256:1a173631124cdb77ffa2cb11ceb8de813f6e4222e5bf9ae657947211480858e6
     name: perl-Module-Signature
     evr: 0.88-1.el9
     sourcerpm: perl-Module-Signature-0.88-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20200520-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14781
     checksum: sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7
     name: perl-Mozilla-CA
     evr: 20200520-6.el9
     sourcerpm: perl-Mozilla-CA-20200520-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-NDBM_File-1.15-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 23899
     checksum: sha256:fbd179e177943079b17db7c887b77dcca46b009ae41d85da5c16e1f33d20a1c9
     name: perl-NDBM_File
     evr: 1.15-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-NEXT-0.67-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21511
     checksum: sha256:85c96161deaf2161fbe1f0d6e46e57d78c5fb839301c94d0782f400066455326
     name: perl-NEXT
     evr: 0.67-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Net-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 27619
     checksum: sha256:79168b438837b36fb8abd5184859651788604c116be0d271fa633276a69662a5
     name: perl-Net
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Net-Ping-2.74-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 53027
     checksum: sha256:fb74fb2651f62421538bb05992af5251887013a72c4412f5c2421992204c03bc
     name: perl-Net-Ping
     evr: 2.74-5.el9
     sourcerpm: perl-Net-Ping-2.74-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.94-1.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 428188
     checksum: sha256:d8ed17b9700c4acee11a339c9e0814862ad5b20e072c1414021dcb050c7da90b
     name: perl-Net-SSLeay
     evr: 1.94-1.el9
     sourcerpm: perl-Net-SSLeay-1.94-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ODBM_File-1.16-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24218
     checksum: sha256:643142aad98f9ed20444345e9dd3a0864203e339ca3e2c27b8f54b06d1376924
     name: perl-ODBM_File
     evr: 1.16-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Object-HashBase-0.009-7.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 28938
     checksum: sha256:2144d4c29ea4acfc0d872bf09cb4d9dce14a64e60a45633f1a31ed3a2b125ee8
     name: perl-Object-HashBase
     evr: 0.009-7.el9
     sourcerpm: perl-Object-HashBase-0.009-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Opcode-1.48-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38723
     checksum: sha256:cd4117212a4033a7f16c260cad82d7032385ccf8122168bfddf775991d4cdbac
     name: perl-Opcode
     evr: 1.48-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-POSIX-1.94-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 100044
     checksum: sha256:70b078b5b692c8d8b26600ae4868b50d613289a89c50b702109bce542d2c8888
     name: perl-POSIX
     evr: 1.94-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Package-Generator-1.106-23.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 26822
     checksum: sha256:2c9b4699185c30d1da293add16911555e93b7532d77e59aa07e2c9c8d8eafcf3
     name: perl-Package-Generator
     evr: 1.106-23.el9
     sourcerpm: perl-Package-Generator-1.106-23.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Params-Check-0.38-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24764
     checksum: sha256:a6cf1009e3f1dfe50e00421b11d43c413e7e4ee8c6931195256a3cb40e1baf7b
     name: perl-Params-Check
     evr: 1:0.38-461.el9
     sourcerpm: perl-Params-Check-0.38-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Params-Util-1.102-5.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 38828
     checksum: sha256:a0a38c672e520e1df5aefa9e5212e0fd5754e3e14f6a6e68b53aba5feb330e99
     name: perl-Params-Util
     evr: 1.102-5.el9
     sourcerpm: perl-Params-Util-1.102-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-PathTools-3.78-461.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 94564
     checksum: sha256:0647785b169c4bbdc65adf06d28981ce7fd1c9f93aecaa4e53a4515a21ebbf81
     name: perl-PathTools
     evr: 3.78-461.el9
     sourcerpm: perl-PathTools-3.78-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Perl-OSType-1.010-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 26284
     checksum: sha256:64f37a98e22fce4ee9520da6db13ab601e21e34ac9d3ae7f85fc7a63761c492b
     name: perl-Perl-OSType
     evr: 1.010-461.el9
     sourcerpm: perl-Perl-OSType-1.010-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-PerlIO-via-QuotedPrint-0.09-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25566
     checksum: sha256:31d1284cda8a84f78574ae2380474412788de756613bcb11a85d68c94af9ba0b
     name: perl-PerlIO-via-QuotedPrint
     evr: 0.09-4.el9
     sourcerpm: perl-PerlIO-via-QuotedPrint-0.09-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Checker-1.74-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 35171
     checksum: sha256:7410aed54bb1c0a18b7b0ec33b6067475383b557defdd295b48b3277229d31a1
     name: perl-Pod-Checker
     evr: 4:1.74-4.el9
     sourcerpm: perl-Pod-Checker-1.74-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Escapes-1.07-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22564
     checksum: sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0
     name: perl-Pod-Escapes
     evr: 1:1.07-460.el9
     sourcerpm: perl-Pod-Escapes-1.07-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Functions-1.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13990
     checksum: sha256:b843dc0a066b663fd00312a2355f0b512b84906a34bbeb1946bcfd9d0f85ce3d
     name: perl-Pod-Functions
     evr: 1.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Html-1.25-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 28371
     checksum: sha256:8275355aecc93d59cf27acfa23cc8567b5a9aff8dff0cc60a446f65643638464
     name: perl-Pod-Html
     evr: 1.25-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 93727
     checksum: sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0
     name: perl-Pod-Perldoc
     evr: 3.28.01-461.el9
     sourcerpm: perl-Pod-Perldoc-3.28.01-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Simple-3.42-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 234403
     checksum: sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a
     name: perl-Pod-Simple
     evr: 1:3.42-4.el9
     sourcerpm: perl-Pod-Simple-3.42-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Pod-Usage-2.01-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 44477
     checksum: sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9
     name: perl-Pod-Usage
     evr: 4:2.01-4.el9
     sourcerpm: perl-Pod-Usage-2.01-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Safe-2.41-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25655
     checksum: sha256:6b4297166c836f624884960f3fd6627dab8238e8665fd660d7fb97287743a16d
     name: perl-Safe
     evr: 2.41-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Scalar-List-Utils-1.56-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 77262
     checksum: sha256:7ce874bde7d9ad15abf70a3b7edbab77548eb2eb8b529c1e48b2426ee7f948f9
     name: perl-Scalar-List-Utils
     evr: 4:1.56-462.el9
     sourcerpm: perl-Scalar-List-Utils-1.56-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Search-Dict-1.07-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13596
     checksum: sha256:867c49e05a2766e22fd09d86b777dd3f97d36b40057f63f360b9f278549f521e
     name: perl-Search-Dict
     evr: 1.07-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-SelectSaver-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12017
     checksum: sha256:c4f02fdf5b501ab67b4824fc4473ba420f482254ad82e90b546d9b10a5464820
     name: perl-SelectSaver
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-SelfLoader-1.26-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 22204
     checksum: sha256:e8d612dcd47d9769dd1502b92ec7606c195273aa9d61ab13c7bc5e7a07359bb3
     name: perl-SelfLoader
     evr: 1.26-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Socket-2.031-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 59776
     checksum: sha256:762751146305f9aea53b74a21495a610e7bdde956fa3246565d265b1128b56a8
     name: perl-Socket
     evr: 4:2.031-4.el9
     sourcerpm: perl-Socket-2.031-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Software-License-0.103014-12.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 147494
     checksum: sha256:c225b78b513fc8b90a0b2b773fadcf65dd2defe2a147fca67c52971d2750f437
     name: perl-Software-License
     evr: 0.103014-12.el9
     sourcerpm: perl-Software-License-0.103014-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Storable-3.21-460.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 100335
     checksum: sha256:0097fdb40a1f83e56d5bf91160c07151b7cdd64f829fc0e328cdf3b43c2b4fa6
     name: perl-Storable
     evr: 1:3.21-460.el9
     sourcerpm: perl-Storable-3.21-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Sub-Exporter-0.987-27.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 78523
     checksum: sha256:4e2535cd4d456f91f346e6d690c9a22c4b2a01318f9a5b5f761e1170d815bed1
     name: perl-Sub-Exporter
     evr: 0.987-27.el9
     sourcerpm: perl-Sub-Exporter-0.987-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Sub-Install-0.928-28.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25233
     checksum: sha256:4ce03d243d1331188c5a2b0e4103dad6b930ba36362cd353f0f3cd0998784e82
     name: perl-Sub-Install
     evr: 0.928-28.el9
     sourcerpm: perl-Sub-Install-0.928-28.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Symbol-1.08-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14535
     checksum: sha256:2364cd3b0a19572b16a1379c228046a405851bcd0676860a6aeb9bcb3869498f
     name: perl-Symbol
     evr: 1.08-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Sys-Hostname-1.23-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 19159
     checksum: sha256:11c22454488c2605fa6ad0c190e81ed27b7b984d13eaed8cf22302135d9008a6
     name: perl-Sys-Hostname
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Sys-Syslog-0.36-461.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52721
     checksum: sha256:b43b2f00357854a3bf0a15e1d41c0494083bc6550b50796b773f4a98ad126734
     name: perl-Sys-Syslog
     evr: 0.36-461.el9
     sourcerpm: perl-Sys-Syslog-0.36-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52228
     checksum: sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23
     name: perl-Term-ANSIColor
     evr: 5.01-461.el9
     sourcerpm: perl-Term-ANSIColor-5.01-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-Cap-1.17-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25043
     checksum: sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17
     name: perl-Term-Cap
     evr: 1.17-460.el9
     sourcerpm: perl-Term-Cap-1.17-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-Complete-1.403-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13574
     checksum: sha256:1d500a1e9dad3d67fff08ac6a7219152a9082f7a92893cfb653171ab198f5e79
     name: perl-Term-Complete
     evr: 1.403-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-ReadLine-1.17-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 19755
     checksum: sha256:2cc16944420d5b8a3318982fc063e4ea2f3d387e1a255d8d08a15f839d8204ff
     name: perl-Term-ReadLine
     evr: 1.17-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-Size-Any-0.002-35.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16309
     checksum: sha256:e83c29bb60e3fdac1c7aa5d3cde8a6b237812a14fe8f711bf6e127ed96d929a4
     name: perl-Term-Size-Any
     evr: 0.002-35.el9
     sourcerpm: perl-Term-Size-Any-0.002-35.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-Size-Perl-0.031-12.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25188
     checksum: sha256:883408c5c76d852a64893986206330ca362ccbbd3535d5ad2fed94ee6e10473e
     name: perl-Term-Size-Perl
     evr: 0.031-12.el9
     sourcerpm: perl-Term-Size-Perl-0.031-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Term-Table-0.015-8.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 40852
     checksum: sha256:3e0c26e1b0e31d17cc133829ad8d6e22c86e532e9b6a3c26f48b7ec447bdfbb4
     name: perl-Term-Table
     evr: 0.015-8.el9
     sourcerpm: perl-Term-Table-0.015-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.38-11.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 41023
     checksum: sha256:5ff266e740a93344e1ce2913f4bec0f38cfdf721841e6762d85ac21d716ee9f8
     name: perl-TermReadKey
     evr: 2.38-11.el9
     sourcerpm: perl-TermReadKey-2.38-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Test-1.31-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 29295
     checksum: sha256:5c8c76bc8d054ae19574fb973541cedf9e56f92c79424a86219e4c1eb65b3227
     name: perl-Test
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Test-Harness-3.42-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 306138
     checksum: sha256:7980ae9e28aed0aadef4f169e8479812a2a6bacf05ee53001f63d021b065fe40
     name: perl-Test-Harness
     evr: 1:3.42-461.el9
     sourcerpm: perl-Test-Harness-3.42-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Test-Simple-1.302183-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 645034
     checksum: sha256:04ae40e07d57934e5dc3946fa638023ee76305dac04bed7813ed338b0a4c2ef2
     name: perl-Test-Simple
     evr: 3:1.302183-4.el9
     sourcerpm: perl-Test-Simple-1.302183-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Abbrev-1.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12713
     checksum: sha256:b172427e49212833e48b699190ad0d34432c102478e869f4974a3f323d0fa375
     name: perl-Text-Abbrev
     evr: 1.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Balanced-2.04-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 51500
     checksum: sha256:67ff60f60b6dc900e840ed51ff3b1cabef9e43aa48cba81ad97ae9423bdca5af
     name: perl-Text-Balanced
     evr: 2.04-4.el9
     sourcerpm: perl-Text-Balanced-2.04-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Diff-1.45-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 45523
     checksum: sha256:5141fc840dc2989b44df904df2cadfdc3b6b9d38a7e4dba2c2db3c14e3dbc060
     name: perl-Text-Diff
     evr: 1.45-13.el9
     sourcerpm: perl-Text-Diff-1.45-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Glob-0.11-15.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15921
     checksum: sha256:079d5eb4a606a131eaeecfcbd7f7d39a21c9c49b97bd6b84f7d08986dd11dc59
     name: perl-Text-Glob
     evr: 0.11-15.el9
     sourcerpm: perl-Text-Glob-0.11-15.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-ParseWords-3.30-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18680
     checksum: sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9
     name: perl-Text-ParseWords
     evr: 3.30-460.el9
     sourcerpm: perl-Text-ParseWords-3.30-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25935
     checksum: sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-460.el9
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Text-Template-1.59-5.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 64485
     checksum: sha256:3c7350777e9d26fe4c02d52e8c4d4e0643ee32f8abfb9e22fc28f5325702924e
     name: perl-Text-Template
     evr: 1.59-5.el9
     sourcerpm: perl-Text-Template-1.59-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Thread-3.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18516
     checksum: sha256:b1f3ce55b43fd98a9d445cc4bb522d60adcc3fa42944641448684d2f8c24077e
     name: perl-Thread
     evr: 3.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Thread-Queue-3.14-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24804
     checksum: sha256:88d838d681ad683970eb8566e8936faabffc3495dd1b555f083a1cd00538291a
     name: perl-Thread-Queue
     evr: 3.14-460.el9
     sourcerpm: perl-Thread-Queue-3.14-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Thread-Semaphore-2.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16298
     checksum: sha256:92f0836359ffea1017fce7dca7d4ca3555e42e38690c21dc92efdd9a6f6110b2
     name: perl-Thread-Semaphore
     evr: 2.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Tie-4.6-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 34318
     checksum: sha256:90cd8a8c7c31137b4f7ed03b1533ab79f88d3c4977e2e795525d5e4ead55212a
     name: perl-Tie
     evr: 4.6-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Tie-File-1.06-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 44505
     checksum: sha256:20fb32eeec0d12f37716a9f955c64305ab14a2ca53b18def3268125b102f318d
     name: perl-Tie-File
     evr: 1.06-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Tie-Memoize-1.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14721
     checksum: sha256:dfec0d0452c982fa468f3e68ea24239ec9588b6202bb9fe4b1356780baeeca4f
     name: perl-Tie-Memoize
     evr: 1.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Tie-RefHash-1.40-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 26260
     checksum: sha256:5519a86c145d83a1633a127f7b0b6a371e6b2b8a647dabff45c2754388504a44
     name: perl-Tie-RefHash
     evr: 1.40-4.el9
     sourcerpm: perl-Tie-RefHash-1.40-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Time-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 20249
     checksum: sha256:0f9b8228482876a79e8369500b750ea0047f2ac715fa40a41b794ef6026292f3
     name: perl-Time
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Time-HiRes-1.9764-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 62596
     checksum: sha256:ce04253e57c1db4fbbc3a3d3e4c0751af9be7c1c7f236be3690a2b304410b172
     name: perl-Time-HiRes
     evr: 4:1.9764-462.el9
     sourcerpm: perl-Time-HiRes-1.9764-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Time-Local-1.300-7.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 37469
     checksum: sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1
     name: perl-Time-Local
     evr: 2:1.300-7.el9
     sourcerpm: perl-Time-Local-1.300-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Time-Piece-1.3401-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 43751
     checksum: sha256:0842dc9ef3112e634b3e2b9863f86f5346c83a2472af0450ec89ab51f1daf07f
     name: perl-Time-Piece
     evr: 1.3401-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-URI-5.09-3.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 128279
     checksum: sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd
     name: perl-URI
     evr: 5.09-3.el9
     sourcerpm: perl-URI-5.09-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Unicode-Collate-1.29-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 782467
     checksum: sha256:caf9c911bbe43ca8cae0cbda64acef1ad39ca30ca8d5d9bc9fb26979f5ed0b9d
     name: perl-Unicode-Collate
     evr: 1.29-4.el9
     sourcerpm: perl-Unicode-Collate-1.29-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Unicode-LineBreak-2019.001-11.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 132083
     checksum: sha256:64b6093e21079433c7d14f0b98a86e8bf032cc312abc1207f4415b8acb00f18b
     name: perl-Unicode-LineBreak
     evr: 2019.001-11.el9
     sourcerpm: perl-Unicode-LineBreak-2019.001-11.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Unicode-Normalize-1.27-461.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 96049
     checksum: sha256:9254f16bef6a0598320196378370728a4881557f5bfeca1ef864a0a25c93f4c0
     name: perl-Unicode-Normalize
     evr: 1.27-461.el9
     sourcerpm: perl-Unicode-Normalize-1.27-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-Unicode-UCD-0.75-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 80630
     checksum: sha256:72dddc4fff3d829ab7b7e5f32dbc027f26f772ffa8f0274224b1cba1d47a778e
     name: perl-Unicode-UCD
     evr: 0.75-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-User-pwent-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 21758
     checksum: sha256:27f572e65b4e0b777c5fe567483f774b4e1c1200ec225e5d817c452812858842
     name: perl-User-pwent
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-autodie-2.34-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 103286
     checksum: sha256:8c4a7c8fd5074801946cce0b0b2f47337036e7f64e4cb9c833d9cf1de1f14edc
     name: perl-autodie
     evr: 2.34-4.el9
     sourcerpm: perl-autodie-2.34-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-autouse-1.11-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14134
     checksum: sha256:b165ef7e5bb8a2b898bbe2b88fe35bc005ef77a5ccf006b055448dc9bed17040
     name: perl-autouse
     evr: 1.11-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-base-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16674
     checksum: sha256:dab1d27f285d579c9783e80817f98a2835e7bf06842d704a7f85cfdb7ab4b0a3
     name: perl-base
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-bignum-0.51-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48635
     checksum: sha256:a25963adbb78901e2581a041252bfc96f55e534403e4af513d8728c62f0b4800
     name: perl-bignum
     evr: 0.51-460.el9
     sourcerpm: perl-bignum-0.51-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-blib-1.07-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 12768
     checksum: sha256:de430b1a162b99600aa6e1def89526c266d7a45d2a0985888859098d06ef4f0e
     name: perl-blib
     evr: 1.07-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-constant-1.33-461.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 25865
     checksum: sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892
     name: perl-constant
     evr: 1.33-461.el9
     sourcerpm: perl-constant-1.33-461.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-debugger-1.56-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 138187
     checksum: sha256:98fe7aa5a1d244e7f61145396cdf6f9248c5f61416ba9bbd1e6cecd0800b52b5
     name: perl-debugger
     evr: 1.56-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-deprecate-0.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14963
     checksum: sha256:4a233b89a6a942448705a26eaa555398d7bc64e710d8a78150f4a96b2207abc8
     name: perl-deprecate
     evr: 0.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-devel-5.32.1-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 696653
     checksum: sha256:101ee7c6e84689808d05333bcb20210e3efc45d148786f4658f729742c53a817
     name: perl-devel
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-diagnostics-1.37-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 216999
     checksum: sha256:c5beafc6150251bb39d8bd19b30cc658b604603e9244aeccb9d747fae73fab5d
     name: perl-diagnostics
     evr: 1.37-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-doc-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 4804041
     checksum: sha256:a107369e340680c1229420021f9b9bf06699efceb6c31197fd870fccb2a12dd6
     name: perl-doc
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-encoding-3.00-462.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 66000
     checksum: sha256:7c5ea804da141c742d05b6d6627481f05310a37e396a02af07e52877afcb534c
     name: perl-encoding
     evr: 4:3.00-462.el9
     sourcerpm: perl-Encode-3.08-462.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-encoding-warnings-0.13-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 17234
     checksum: sha256:4db8e5730e9135e68ee10c0d5f8ca2095cfc5f2b548febe6aad2caaba61d8921
     name: perl-encoding-warnings
     evr: 0.13-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-experimental-0.022-6.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 24376
     checksum: sha256:ae48d202863aba2573c70d803a9931de4e3c4b0d3e4f2df561bcc1bf78dc7920
     name: perl-experimental
     evr: 0.022-6.el9
     sourcerpm: perl-experimental-0.022-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-fields-2.27-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16577
     checksum: sha256:25f2bce872cdd91240c5a42b0ee6990db0b51bb51bdcee6fa441aa4889b9bd84
     name: perl-fields
     evr: 2.27-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-filetest-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15022
     checksum: sha256:3ba9775352bcb0aa76a6321ce582f028f23223743eecfdcd8458da05636f8436
     name: perl-filetest
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-if-0.60.800-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14343
     checksum: sha256:714022b8937ed9c6d4638b99aef0a8426b782e7948019b50b06d9cd2e32e454a
     name: perl-if
     evr: 0.60.800-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-inc-latest-0.500-20.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 27665
     checksum: sha256:22c41d7117656dfff8d52bc8e557e6f8d11d2b5ed377173f56037a2ac8bc9139
     name: perl-inc-latest
     evr: 2:0.500-20.el9
     sourcerpm: perl-inc-latest-0.500-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-interpreter-5.32.1-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 74840
     checksum: sha256:359a94a09f0082a637c5bc2aa4ddac23dd79e929daa38dfed85d0e1afff31fba
     name: perl-interpreter
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-less-0.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13545
     checksum: sha256:268da168b25a97a8be8c736217a60e12ea54b0a67261cf7dd8199297a3dd10e3
     name: perl-less
     evr: 0.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-lib-0.65-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 15318
     checksum: sha256:89bf58fb4d09ec404ea98063d4a7099ff00b59e9a9e0bb04067f48e3fb581083
     name: perl-lib
     evr: 0.65-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-libnet-3.13-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 137289
     checksum: sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98
     name: perl-libnet
     evr: 3.13-4.el9
     sourcerpm: perl-libnet-3.13-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-libnetcfg-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16729
     checksum: sha256:c9e9bbf74d825bb623ae797f35b38d31ea03aede18900bcbe624bc95de2c389a
     name: perl-libnetcfg
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-libs-5.32.1-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 2303445
     checksum: sha256:d20aebf4d96f4ad0e7dc97b63bbe41baa6f927a34eac9068a22f1d62e71611dc
     name: perl-libs
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-local-lib-2.000024-13.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 73510
     checksum: sha256:c8f58afb9e8eb07bc57f92c384753ee4f4fec10fa7ec7c091ad9f15110a10026
     name: perl-local-lib
     evr: 2.000024-13.el9
     sourcerpm: perl-local-lib-2.000024-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-locale-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14021
     checksum: sha256:35930019be1e37fa53b29cc9af6326443a96817024120948ca89556b1db06eda
     name: perl-locale
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-macros-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 10809
     checksum: sha256:4afe9e549dcaad11ec3f6ac2d89595b8d8ad37e305f4d70f7de2ec70d1f90ded
     name: perl-macros
     evr: 4:5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-meta-notation-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9810
     checksum: sha256:a6ce87fee7568af4803818fe9715c3253b5b6401e88c2b20bdc07eec9d664bd2
     name: perl-meta-notation
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-mro-1.23-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 30125
     checksum: sha256:3cf76960b8c866deebf333a9dfd64a7dd9f4689cb82e37d0c0ddab2c031b3651
     name: perl-mro
     evr: 1.23-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-open-1.12-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16871
     checksum: sha256:52897741a5e6d526aa0de31438c48aa0f1f40c2fdd15720c4956e79e01830898
     name: perl-open
     evr: 1.12-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-overload-1.31-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 46643
     checksum: sha256:813598b9d9a3ada4975144cf0dd0f25906589a92c7708556dcbf464501d72848
     name: perl-overload
     evr: 1.31-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-overloading-0.02-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13658
     checksum: sha256:feca093162af099f769448e95170a357f2d2bd66da36299d1a999782d57da51d
     name: perl-overloading
     evr: 0.02-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-parent-0.238-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16286
     checksum: sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463
     name: perl-parent
     evr: 1:0.238-460.el9
     sourcerpm: perl-parent-0.238-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-perlfaq-5.20201107-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 388433
     checksum: sha256:6f876ec91543f837fb0a212d0265a12dd0505ca3ee706fca81275e3ab2af79a4
     name: perl-perlfaq
     evr: 5.20201107-4.el9
     sourcerpm: perl-perlfaq-5.20201107-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-ph-5.32.1-481.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 49514
     checksum: sha256:091fc89520aab20f245ac9554ffe25cf06691133832421199455b983537c3e06
     name: perl-ph
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-podlators-4.14-460.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 121317
     checksum: sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98
     name: perl-podlators
     evr: 1:4.14-460.el9
     sourcerpm: perl-podlators-4.14-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-sigtrap-1.09-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 16091
     checksum: sha256:4c42029372306ee2cf559e3b4f899c2170d2088f26b66a0f29ac1d8cb66b5387
     name: perl-sigtrap
     evr: 1.09-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-sort-2.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13868
     checksum: sha256:f4aedfdb824193f1aa0f45ee092e2f887f3734065861a90b4e089a6e1f9cfab1
     name: perl-sort
     evr: 2.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-srpm-macros-1-41.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9639
     checksum: sha256:fa6a45cf7cb8b6f8a28ce85be31483eacc7b0b4c01d598123ec649867b67c8f4
     name: perl-srpm-macros
     evr: 1-41.el9
     sourcerpm: perl-srpm-macros-1-41.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-subs-1.03-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11986
     checksum: sha256:df6327eb3774c2254fc45c630cedf3b32b3bdd7f146bf25ffe0342f9904dac43
     name: perl-subs
     evr: 1.03-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-threads-2.25-460.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 62702
     checksum: sha256:22546db61ccd2c69020c7ec3b04449b3589e1220dd3a02ad38e6d6c773ae126f
     name: perl-threads
     evr: 1:2.25-460.el9
     sourcerpm: perl-threads-2.25-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-threads-shared-1.61-460.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48850
     checksum: sha256:3ee2cd37764da3452fbaa301f9bdf3ae1a2dba47b77cafb0ae5d31a10196b971
     name: perl-threads-shared
     evr: 1.61-460.el9
     sourcerpm: perl-threads-shared-1.61-460.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-utils-5.32.1-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 58445
     checksum: sha256:3af8e12fe87b871c3a4ed52188ff716b8d9b62030d8ecc2c019de7e4a65f2809
     name: perl-utils
     evr: 5.32.1-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-vars-1.05-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 13347
     checksum: sha256:c54caddd2a5adaf84088833a9eb126e772b6db090800c3293b819f432ddd6b6c
     name: perl-vars
     evr: 1.05-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-version-0.99.28-4.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 68996
     checksum: sha256:8804f201f3e2fb54f75735683c65a571f17b6ea8715e84eb813907ec5027fcc5
     name: perl-version
     evr: 7:0.99.28-4.el9
     sourcerpm: perl-version-0.99.28-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/perl-vmsish-1.04-481.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14503
     checksum: sha256:e27e656ae98a4d98e95a9bb6fdeaaae819bf692e8169d8a58ca2e0c564dfe3c9
     name: perl-vmsish
     evr: 1.04-481.el9
     sourcerpm: perl-5.32.1-481.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 277483
     checksum: sha256:40581f27200096a57adc25a51d3d373a81f55d3abc0529cbe057c2c458318145
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/pyproject-srpm-macros-1.12.0-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 14645
     checksum: sha256:e19955e05af502a66d28246f083dfeed32cb7cfb56feced5c51b33cde77172b2
     name: pyproject-srpm-macros
     evr: 1.12.0-1.el9
     sourcerpm: pyproject-rpm-macros-1.12.0-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-srpm-macros-3.9-54.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 18705
     checksum: sha256:cc14196e07f9c6383f5bdf2c1171e7d41256326324c4a03c98d62d81413f3fb3
     name: python-srpm-macros
     evr: 3.9-54.el9
     sourcerpm: python-rpm-macros-3.9-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-1.el9_5.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 10813
     checksum: sha256:9409fab1b252ea2717b593cdc96227ead9fdf7040c4d5391f33352e3d193842e
     name: python-unversioned-command
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/q/qt5-srpm-macros-5.15.9-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 9344
     checksum: sha256:1dbb5db859d110aa275cbacd07e2576dcbe321ab0803f04d85dc3fa1a203ef10
     name: qt5-srpm-macros
     evr: 5.15.9-1.el9
     sourcerpm: qt5-5.15.9-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/redhat-rpm-config-208-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 77229
     checksum: sha256:257cb0ffa77bff30467daa8f3bc8b867c86a6c532af424e86fae595cef6685d5
     name: redhat-rpm-config
     evr: 208-1.el9
     sourcerpm: redhat-rpm-config-208-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-srpm-macros-17-4.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 11243
     checksum: sha256:8e91d6d5122b9effe0e3539ef0d55e57c4b3eff68544e46a413129cb961d5941
     name: rust-srpm-macros
     evr: 17-4.el9
     sourcerpm: rust-srpm-macros-17-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/sombok-2.4.0-16.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 52190
     checksum: sha256:830082e28c0d9a2a1e055f0b01e460e5aa54336f57c2a6885a1f4c748f55fe11
     name: sombok
     evr: 2.4.0-16.el9
     sourcerpm: sombok-2.4.0-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/sysprof-capture-devel-3.40.1-3.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 65413
     checksum: sha256:3006309779a18bde4fff7e633881218284a46584e4d529a14fbbc4bc0683ebae
     name: sysprof-capture-devel
     evr: 3.40.1-3.el9
     sourcerpm: sysprof-3.40.1-3.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/s/systemtap-sdt-devel-5.1-4.el9_5.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 79017
     checksum: sha256:3cb47945ff6e2491a8c328c87b7e3e82342ccde54e1a112adacfc1706f90738d
     name: systemtap-sdt-devel
     evr: 5.1-4.el9_5
     sourcerpm: systemtap-5.1-4.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/v/vim-common-8.2.2637-21.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 7351330
     checksum: sha256:df17c735c75243ce95bdfc71377b726f00938cd5c03ed00cc4ebb63fe65d17ba
     name: vim-common
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/v/vim-enhanced-8.2.2637-21.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 1833618
     checksum: sha256:0151b56d80b854b23224af13c6092f077358e8e7ade435c82ecf7855cfc5a7ab
     name: vim-enhanced
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/x/xml-common-0.6.3-58.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 37016
     checksum: sha256:2278e3b1ce7ddd4ff394064e5dc5404ac2799e51f9441a056b334d518bb51af4
     name: xml-common
     evr: 0.6.3-58.el9
     sourcerpm: sgml-common-0.6.3-58.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/x/xorg-x11-proto-devel-2024.1-1.el9.noarch.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 321971
     checksum: sha256:1ad6ee7c810cdacaf1b6d04f09c8a3e38fb14751c3289b800a18127698dc51d9
     name: xorg-x11-proto-devel
     evr: 2024.1-1.el9
     sourcerpm: xorg-x11-proto-devel-2024.1-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/x/xz-devel-5.2.5-8.el9_0.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 60644
     checksum: sha256:f4bd3abbd2101e636d61c7bfc0c176e0b24e48da77c767fc3d07859fd8001d56
     name: xz-devel
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/z/zlib-devel-1.2.11-40.el9.x86_64.rpm
-    repoid: ubi-9-appstream-rpms
+    repoid: ubi-9-for-x86_64-appstream-rpms
     size: 48017
     checksum: sha256:9775022716a2b6dd51d151a40aa4a6bcb466edeb01b747f48072703e509be097
     name: zlib-devel
     evr: 1.2.11-40.el9
     sourcerpm: zlib-1.2.11-40.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 77226
     checksum: sha256:150d7232faa90f84a09268f8998ee32670eef59cba98612aeb996ab75c4dfcc4
     name: acl
     evr: 2.3.1-4.el9
     sourcerpm: acl-2.3.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-54.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 4816328
     checksum: sha256:58286130e67839b931412baa9cb1efcb42d02dc3d1b84caed2ba711773c47ec9
     name: binutils
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-54.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 752302
     checksum: sha256:44ace5e347a8aaad0ae8a449c5d87f69314def94b45bbd1a22a6bd827b549d95
     name: binutils-gold
     evr: 2.35.2-54.el9
     sourcerpm: binutils-2.35.2-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 100903
     checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
     name: cracklib
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 3821230
     checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
     name: cracklib-dicts
     evr: 2.9.6-27.el9
     sourcerpm: cracklib-2.9.6-27.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 8073
     checksum: sha256:96b1daa4de0a635ab760a8431fb005022bb7cb48d2d1d3ec9a8adb1798c0e10e
     name: dbus
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 179634
     checksum: sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb
     name: dbus-broker
     evr: 28-7.el9
     sourcerpm: dbus-broker-28-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 18551
     checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
     name: dbus-common
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 411559
     checksum: sha256:2d4c4fdfc10215af3c957c24995b79a26e27e6d76de4ed1f5198d25bf7ef9671
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.191-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 39913
     checksum: sha256:9c26ab1eea196541d9cde34a96acbf8647746ccd0447ad353dec5ec4225826a5
     name: elfutils-debuginfod-client
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.191-4.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 12782
     checksum: sha256:e186f5fb020da75279f726a9a09bfefd8c60131157debd9ca0966036fd3b8d70
     name: elfutils-default-yama-scope
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.191-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 215143
     checksum: sha256:9d7a6e028b8db0041ffecb41b5a4c2a3351bc09b098d0285f418f7ee16923e63
     name: elfutils-libelf
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.191-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 268507
     checksum: sha256:d58ed4ac90958033cb2e0f3455e7f229e03e85c86ee43636de925ab1369b50aa
     name: elfutils-libs
     evr: 0.191-4.el9
     sourcerpm: elfutils-0.191-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-3.el9_5.1.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 121783
     checksum: sha256:e9b4eb1c8a2ca7787a8ffea53b2a86533a1eb6aea72f05919c2748cd63dad32a
     name: expat
     evr: 2.5.0-3.el9_5.1
     sourcerpm: expat-2.5.0-3.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 53222
     checksum: sha256:64f29bc71f9c26e6460abaff21d8e43738077cde4fbd6d1b96825a50ba0abd74
     name: file
     evr: 5.39-16.el9
     sourcerpm: file-5.39-16.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 563531
     checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
     name: findutils
     evr: 1:4.8.0-7.el9
     sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/freetype-2.10.4-9.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 399961
     checksum: sha256:bf9f5cf6b9e80159e87d0bb57f357124b00325e4cfbca7989e6a08c56a8abac6
     name: freetype
     evr: 2.10.4-9.el9
     sourcerpm: freetype-2.10.4-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gettext-0.21-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1193150
     checksum: sha256:febf6aec8699ca352aba5a7a249ed0cb011b68c5bab17f6178f09b1035974dde
     name: gettext
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gettext-libs-0.21-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 313328
     checksum: sha256:b319325e941e03e3e7381161889ab39473398194786a52fc1653d025211b6e1a
     name: gettext-libs
     evr: 0.21-8.el9
     sourcerpm: gettext-0.21-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-gconv-extra-2.34-125.el9_5.1.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1796886
     checksum: sha256:e4625f4ab64dfb0b89a93390ea3bb699479d78bbcc36d4d76942416d68c4dc75
     name: glibc-gconv-extra
     evr: 2.34-125.el9_5.1
     sourcerpm: glibc-2.34-125.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/graphite2-1.3.14-9.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 100358
     checksum: sha256:15c9ec729831ec8f511cb8595d5bbe7cf5b178dde909e48daed72652d416d54c
     name: graphite2
     evr: 1.3.14-9.el9
     sourcerpm: graphite2-1.3.14-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/groff-base-1.22.4-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1133828
     checksum: sha256:4d8ff13569b3b231b3fb847e9e22615c6e08215d1f2c0c78eac2e345b9efd394
     name: groff-base
     evr: 1.22.4-10.el9
     sourcerpm: groff-1.22.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 171206
     checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/h/harfbuzz-2.7.4-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 643610
     checksum: sha256:ccbdbf1ccae7f9c1315c3a33c103c6d27916e6fdc62756083fe3207474c51537
     name: harfbuzz
     evr: 2.7.4-10.el9
     sourcerpm: harfbuzz-2.7.4-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/k/kmod-libs-28-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 66607
     checksum: sha256:9ae0b89812908ee50ec654ba35f74dc478057e8981afd4a5cc8d2befd987b342
     name: kmod-libs
     evr: 28-10.el9
     sourcerpm: kmod-28-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 170758
     checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
     name: less
     evr: 590-5.el9
     sourcerpm: less-590-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libaio-0.3.111-13.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 27100
     checksum: sha256:20a5a375bd1a12950ba6ca5e4ca9f6af11020214da304317070803be37afd27c
     name: libaio
     evr: 0.3.111-13.el9
     sourcerpm: libaio-0.3.111-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-7.el9_5.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 323932
     checksum: sha256:bb3175e435723e98cc1a5063eafa82231092eca3bf6276d24505eaeaaa817113
     name: libbrotli
     evr: 1.0.9-7.el9_5
     sourcerpm: brotli-1.0.9-7.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libdb-5.3.28-54.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 754801
     checksum: sha256:599dbc91894bde538297d859cd5efd64e95b5b06ffac2c0057b32b1be6c8d9ac
     name: libdb
     evr: 5.3.28-54.el9
     sourcerpm: libdb-5.3.28-54.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 30371
     checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
     name: libeconf
     evr: 0.4.1-4.el9
     sourcerpm: libeconf-0.4.1-4.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 109330
     checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-20.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 158733
     checksum: sha256:f0c0fc67a144dffcef138044c0a563ac9cdb4fa7b00a8e7c4c77e48e9ca35487
     name: libfdisk
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-5.el9_5.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 269396
     checksum: sha256:da7af36960df4b59178f4d7c42353d48c53fbe231e7e62d734a4319748f897a9
     name: libgomp
     evr: 11.5.0-5.el9_5
     sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libicu-67.1-9.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 10023600
     checksum: sha256:d6a263811f4752dfaeb28c7e0f37f8300ed2355e66c5ad994f7ae2a4a4ac6fdd
     name: libicu
     evr: 67.1-9.el9
     sourcerpm: icu-67.1-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 38387
     checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
     name: libpkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 121655
     checksum: sha256:42e7addb96958b293571949829378c054d6a1a762dccb78d5a777f8c531fc811
     name: libpng
     evr: 2:1.6.37-12.el9
     sourcerpm: libpng-1.6.37-12.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 126104
     checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 76200
     checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
     name: libseccomp
     evr: 2.5.2-2.el9
     sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libselinux-utils-3.6-1.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 198772
     checksum: sha256:479229e7c3d8cb005dafd637b2973fbee0bb507cfed8e72f7076318513200abd
     name: libselinux-utils
     evr: 3.6-1.el9
     sourcerpm: libselinux-3.6-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 30354
     checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 553896
     checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
     name: make
     evr: 1:4.3-8.el9
     sourcerpm: make-4.3-8.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/n/ncurses-6.2-10.20210508.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 420158
     checksum: sha256:1b5e5805334bc78c977d7acf02256021a9216e26348a5383cf86dfb0b0c91101
     name: ncurses
     evr: 6.2-10.20210508.el9
     sourcerpm: ncurses-6.2-10.20210508.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1420999
     checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
     name: openssl
     evr: 1:3.2.2-6.el9_5.1
     sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-22.el9_5.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 647471
     checksum: sha256:d0c495a13f0c6d0fdefc309086a81e64eb852255ce64a45b766187bd09de41d0
     name: pam
     evr: 1.5.1-22.el9_5
     sourcerpm: pam-1.5.1-22.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 45675
     checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 16054
     checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
     name: pkgconf-m4
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 12438
     checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
     name: pkgconf-pkg-config
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-2.1.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 251967
     checksum: sha256:8dcd39960d3103f7a4ad2b9f7a0e15469ebf4da98f6c215cddfffdb830dc12b5
     name: policycoreutils
     evr: 3.6-2.1.el9
     sourcerpm: policycoreutils-3.6-2.1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 361526
     checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
     name: procps-ng
     evr: 3.3.17-14.el9
     sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.21-1.el9_5.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 30760
     checksum: sha256:2afbe12057e84e1fe11e82140624c6c71a2688b495499336ca50753a40974b14
     name: python3
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-1.el9_5.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 8490001
     checksum: sha256:bd3351b048dc50776a010bc38c7666ac1c335169c6d0b55c65cee47150520780
     name: python3-libs
     evr: 3.9.21-1.el9_5
     sourcerpm: python3.9-3.9.21-1.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1193706
     checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
     name: python3-pip-wheel
     evr: 21.3.1-1.el9
     sourcerpm: python-pip-21.3.1-1.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-pyparsing-2.4.7-9.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 157800
     checksum: sha256:4c7b1bbabe7f37d1dd098c9d893f7f8e97e5fd43aa8fa4d4c58a3b6b66e69c70
     name: python3-pyparsing
     evr: 2.4.7-9.el9
     sourcerpm: pyparsing-2.4.7-9.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 480100
     checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
     name: python3-setuptools-wheel
     evr: 53.0.0-13.el9
     sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/r/rpm-plugin-selinux-4.16.1.3-34.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 18220
     checksum: sha256:add02cbf42634db0957eda097c5bcac643b19663885645355fd941b8cee175ac
     name: rpm-plugin-selinux
     evr: 4.16.1.3-34.el9
     sourcerpm: rpm-4.16.1.3-34.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.45-3.el9_5.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 52484
     checksum: sha256:217d992f42cab6cae7b0236daeefe78d067f882481f20316198e0736f1325ab2
     name: selinux-policy
     evr: 38.1.45-3.el9_5
     sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.45-3.el9_5.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 7225392
     checksum: sha256:575305a4fc873ef9b1fcaf6005a6f04be6d3ff4a5887d6db8ed97cef23c501c5
     name: selinux-policy-targeted
     evr: 38.1.45-3.el9_5
     sourcerpm: selinux-policy-38.1.45-3.el9_5.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-252-46.el9_5.2.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 4427820
     checksum: sha256:616c315b74c798d12fa0299a0ae0bdaaef42b011af669923ba6c71e5796dfeb9
     name: systemd
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-46.el9_5.2.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 293603
     checksum: sha256:26c788e238d6ccbea0a6129129d2ca284fe578e38a59ecd21e740af8f2a788f4
     name: systemd-pam
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-46.el9_5.2.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 76871
     checksum: sha256:e7805025edd419b440dfc3948201b0ef1dee7e2f51005000dfedb832d1e17cab
     name: systemd-rpm-macros
     evr: 252-46.el9_5.2
     sourcerpm: systemd-252-46.el9_5.2.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/unzip-6.0-57.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 190691
     checksum: sha256:95bf43f66a297fc75b01dfb766d3720bb75f04f8cbd84aa0c1952a573a199e80
     name: unzip
     evr: 6.0-57.el9
     sourcerpm: unzip-6.0-57.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-2.37.4-20.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 2396057
     checksum: sha256:812b87a70ec6f88e493f15b66453112bc67f11576d4d7fa70ad85e914ead366a
     name: util-linux
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-20.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 479544
     checksum: sha256:28cef63cbaf5dedcb87404321027634bd4abcf0ee195879882240942260f60a6
     name: util-linux-core
     evr: 2.37.4-20.el9
     sourcerpm: util-linux-2.37.4-20.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/v/vim-filesystem-8.2.2637-21.el9.noarch.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 17783
     checksum: sha256:a9fce2685b6dfe72b19ca93b274ff1ce709d14e6a8eb48eec5cd4a0d8205015b
     name: vim-filesystem
     evr: 2:8.2.2637-21.el9
     sourcerpm: vim-8.2.2637-21.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/w/which-2.21-29.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 45737
     checksum: sha256:ecfb8a10701375e0f7936825c920113842d63537f1994d915e7f77ec271d2ffb
     name: which
     evr: 2.21-29.el9
     sourcerpm: which-2.21-29.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/z/zip-3.0-35.el9.x86_64.rpm
-    repoid: ubi-9-baseos-rpms
+    repoid: ubi-9-for-x86_64-baseos-rpms
     size: 276200
     checksum: sha256:ef28011ba191f53260cebb1e42b0148ae65d9029940146699e802f501dba009c
     name: zip

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,60 +1,60 @@
-[ubi-9-baseos-rpms]
+[ubi-9-for-$basearch-baseos-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-baseos-debug-rpms]
+[ubi-9-for-$basearch-baseos-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-baseos-source-rpms]
+[ubi-9-for-$basearch-baseos-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-rpms]
+[ubi-9-for-$basearch-appstream-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-debug-rpms]
+[ubi-9-for-$basearch-appstream-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-appstream-source-rpms]
+[ubi-9-for-$basearch-appstream-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-rpms]
+[codeready-builder-for-ubi-9-$basearch-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-debug-rpms]
+[codeready-builder-for-ubi-9-$basearch-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-codeready-builder-source-rpms]
+[codeready-builder-for-ubi-9-$basearch-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
 enabled = 0


### PR DESCRIPTION
Update to use Konflux supported RPM repos identifiers
- https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml
- https://url.corp.redhat.com/d54f834