### PR TITLE
Build the arm64 flavor using a native arm64 action runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
 
   build-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Clone repository
@@ -63,11 +63,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0  # fetches all commits/tags
-
-      - name: Install qemu dependency
-        run: |
-           sudo apt-get update
-           sudo apt-get install -y qemu-user-static
 
       - name: Define Release Tag Arm64
         id: define-release-tag-arm64


### PR DESCRIPTION
- Build the arm64 flavor on a native arm64 github action runner and dropping the need for qemu (ubuntu-24.04-arm).