### PR TITLE
build(tekton): in release builds push to repo after latest tasks.

### DIFF
--- a/.tekton/rhproxy-engine-container-release-push.yaml
+++ b/.tekton/rhproxy-engine-container-release-push.yaml
@@ -628,6 +628,8 @@ spec:
       - clair-scan
       - clamav-scan
       - sast-snyk-check
+      - sast-shell-check
+      - sast-unicode-check
       - rpms-signature-scan
     workspaces:
     - name: git-auth


### PR DESCRIPTION
- During release builds, push to external repo after the sast-shell-check and sast-unicode-check run.