### PR TITLE
fix: update the default worker_processes

### DIFF
--- a/app/etc/nginx/nginx.conf.template
+++ b/app/etc/nginx/nginx.conf.template
@@ -1,7 +1,7 @@
 
 load_module "/opt/app-root/nginx/usr/lib64/nginx/modules/ngx_http_proxy_connect_module.so";
 
-worker_processes 1;
+worker_processes auto;
 error_log /dev/stderr notice;
 pid /run/nginx.pid;
 


### PR DESCRIPTION
- We need to up the worker_processes which is set to 1 by default as this could make the server more vulnerable to DoS attacks as it may not be able to handle as much load.
- Upping to "auto" as Nginx will allocate based on available CPU's as each system may be different.

Resolves: https://redhat.atlassian.net/browse/IPP-47

## Summary by Sourcery

Enhancements:
- Configure Nginx worker_processes to use the auto setting instead of the default single worker to better utilize system resources and handle higher load.